### PR TITLE
fix: reap all cross-navigation state on warm Page reuse (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.1]
+
+### Fixed
+- **`PagePool` / warm reuse leaked V8 heap without bound**
+  ([#33](https://github.com/yfedoseev/browser_oxide/issues/33)). Reusing a
+  `Page` across navigations grew V8's live (non-collectable) heap by ~10 MB
+  per page, eventually OOMing long batches. Every one of the engine's reapers
+  was wired only to `Page::drop`, which a pool by definition never reaches,
+  and the bootstrap JS keeps several registries scoped to the `JsRuntime`
+  rather than to the document. Now reaped on reuse:
+  - all registered event listeners (`__cancelAllListeners()` in
+    `event_bootstrap.js`) — `window`-bound listeners were keyed against the
+    one object that outlives every navigation, so their closures pinned the
+    previous page's entire object graph, and `_nodeListeners` was a strong
+    `Map` that was never pruned at all;
+  - the DOM node-wrapper cache, scroll state, `MutationObserver` registry,
+    and iframe/frame registries (`__resetDomRegistries()`);
+  - custom-element definitions (`__resetCustomElements()`);
+  - globals the page hung off `window` (`__resetPageGlobals()`), diffed
+    against a baseline the engine marks before any page script runs.
+- **Warm reuse misfired the previous page's handlers on the new document.**
+  `_nodeListeners` and the node-wrapper cache are keyed by `nodeId`, and node
+  IDs restart at zero when `replace_dom` swaps the document — so the old
+  page's listener for node 42 fired on the new page's node 42, and the new
+  page's node could be handed the old page's wrapper (with its expandos).
+  Fixed by the same reset.
+- **Custom elements could not be re-defined across a warm navigation.**
+  `customElements.define()` for a name the *previous* page had registered was
+  a silent no-op, so the new page's class never upgraded.
+- `Page::navigate_warm` left `__keepLongTimersRefed` set after a challenge
+  page, pinning long timers on every subsequent navigation of that `Page`.
+- **The CDP protocol server leaked the same way.** `Page.navigate` swaps the
+  document with `reload_html` on a `Page` the session keeps alive for its
+  whole lifetime, so it accumulated the previous document's state for as long
+  as a client stayed connected. It now resets between documents.
+- Page-assigned `on*` handlers (`window.onscroll = …`, `document.onclick = …`)
+  survived reuse. These already exist as own properties at bootstrap, so a
+  key-set diff cannot see the assignment; handler *values* are now snapshotted
+  at baseline and restored, which clears page assignments while preserving the
+  engine's own `window.onerror` instrumentation.
+
+### Added
+- `Page::reset_for_reuse()` — public, bundles every cross-navigation reaper
+  (timers, listeners, DOM registries, custom elements, page globals, orphan
+  Workers, child iframe isolates). Consumers that hand-roll page reuse — e.g.
+  calling `Page::reload_html` on a `Page` they keep alive — should call this
+  between documents; `PagePool`, `Page::navigate_warm` and the CDP server
+  already do.
+- `Page::v8_heap_used_bytes()` and `Page::collect_garbage()` (also on
+  `BrowserJsRuntime`) — lets pool operators verify heap health directly.
+  Sample after each navigation; a healthy pool stays flat.
+
+### Removed
+- Dead `_listeners` registry in `event_bootstrap.js` (declared, never read).
+
 ## [0.1.0] — 2026-06-13
 
 > First open-source release of BrowserOxide — a from-scratch stealth headless

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "adblock",
  "async-trait",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide_mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "browser_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/browser_oxide", "crates/browser_oxide_mcp"]
 exclude = ["crates/browser_oxide_py"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Yury Fedoseev"]
@@ -39,7 +39,7 @@ doc_overindented_list_items = "allow"
 # The single engine crate — depended on by browser_oxide_mcp. Explicit
 # version pinned to the workspace version so cargo-deny's `wildcards =
 # "deny"` rule doesn't trip on path-only `version = "*"` resolution.
-browser_oxide = { version = "0.1.0", path = "crates/browser_oxide" }
+browser_oxide = { version = "0.1.1", path = "crates/browser_oxide" }
 
 # Async runtime + common derive deps shared by multiple crates.
 tokio = { version = "1", features = ["full"] }

--- a/crates/browser_oxide/src/js_runtime/js/cleanup_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/cleanup_bootstrap.js
@@ -633,6 +633,123 @@
         internals.push('SharedArrayBuffer');
     }
 
+    // -- Warm-reuse global-namespace reset ---------------------------
+    // The last retention source for a pooled `Page`: properties page
+    // scripts hang straight off the global (`window.__APP_STATE = …`,
+    // `window.onscroll = …`, framework singletons). `globalThis` is the
+    // same object for the whole life of the `JsRuntime`, so on the warm
+    // path every one of those — and everything they transitively
+    // reference — survives into the next navigation. A real browser gives
+    // each navigation a fresh global; this is the closest equivalent that
+    // keeps the expensive bootstrap intact.
+    //
+    // `__markGlobalsBaseline()` snapshots the engine-owned key set;
+    // `__resetPageGlobals()` deletes everything added since. Rust re-marks
+    // the baseline once more after it installs the post-bootstrap
+    // instrumentation (`__cookieWrites` / `__scriptErrors` / the fetch +
+    // XHR wrappers), which is why those names are also allowlisted below —
+    // construction paths that skip the re-mark must not lose them.
+    // Note `window === globalThis` here (dom_bootstrap.js), so scrubbing
+    // the global object covers both.
+    // Guarded: this file is executed TWICE per page — once from
+    // `BrowserJsRuntime`'s constructor (before any page script) and again
+    // from `build_page_with_scripts_*` after the document's scripts have
+    // run. Only the first execution may seed the baseline; re-running the
+    // definitions would also reset the closure variable and throw the real
+    // baseline away.
+    if (typeof globalThis.__resetPageGlobals !== 'function') {
+        let _globalsBaseline = null;
+        let _onHandlerBaseline = null;
+        const _BASELINE_ALWAYS = [
+            '_browser_oxide', '__cookieWrites', '__scriptErrors',
+            '__bo_input_events', '__jsCookies',
+        ];
+
+        // `on*` handlers need value-level treatment, not just key-level.
+        // `onscroll`, `onerror`, … already EXIST as own properties of the
+        // global at bootstrap (default `null`), so a page that assigns
+        // `window.onscroll = fn` mutates a baseline key rather than adding
+        // one — the key-set diff below cannot see it, and the closure (plus
+        // everything it captures) survives the navigation.
+        //
+        // Blanket-nulling them is wrong: the engine itself installs
+        // `window.onerror` as its script-error instrumentation, once, and
+        // does NOT re-install it on the warm path. So snapshot the values
+        // at baseline and RESTORE them, which nulls page assignments while
+        // preserving the engine's.
+        const _snapshotOnHandlers = (target) => {
+            const m = new Map();
+            if (!target) return m;
+            let names;
+            try { names = Object.getOwnPropertyNames(target); } catch (_e) { return m; }
+            for (const k of names) {
+                if (!k.startsWith('on')) continue;
+                try { m.set(k, target[k]); } catch (_e) {}
+            }
+            return m;
+        };
+        const _restoreOnHandlers = (target, baseline) => {
+            if (!target || !baseline) return;
+            let names;
+            try { names = Object.getOwnPropertyNames(target); } catch (_e) { return; }
+            for (const k of names) {
+                if (!k.startsWith('on')) continue;
+                try {
+                    if (typeof target[k] !== 'function') continue;
+                    const orig = baseline.get(k);
+                    // Already the engine's own handler ⇒ leave it alone.
+                    if (orig === target[k]) continue;
+                    target[k] = (typeof orig === 'function') ? orig : null;
+                } catch (_e) {}
+            }
+        };
+
+        Object.defineProperty(globalThis, '__markGlobalsBaseline', {
+            value: function __markGlobalsBaseline() {
+                const seen = new Set(_BASELINE_ALWAYS);
+                for (const k of Object.getOwnPropertyNames(globalThis)) seen.add(k);
+                for (const s of Object.getOwnPropertySymbols(globalThis)) seen.add(s);
+                _globalsBaseline = seen;
+                // `document` is a singleton that survives `replace_dom`, so
+                // `document.onclick = fn` persists exactly like the window
+                // case and needs the same treatment.
+                _onHandlerBaseline = {
+                    global: _snapshotOnHandlers(globalThis),
+                    document: _snapshotOnHandlers(globalThis.document),
+                };
+            },
+            writable: true, configurable: true, enumerable: false,
+        });
+        Object.defineProperty(globalThis, '__resetPageGlobals', {
+            value: function __resetPageGlobals() {
+                // No baseline ⇒ nothing to compare against; deleting on a
+                // guess would strip the engine's own globals.
+                if (!_globalsBaseline) return 0;
+                let removed = 0;
+                const keys = Object.getOwnPropertyNames(globalThis)
+                    .concat(Object.getOwnPropertySymbols(globalThis));
+                for (const k of keys) {
+                    if (_globalsBaseline.has(k)) continue;
+                    // Best-effort: a page can install a non-configurable
+                    // property, and `delete` cannot remove those.
+                    try { if (delete globalThis[k]) removed++; } catch (_e) {}
+                }
+                if (_onHandlerBaseline) {
+                    _restoreOnHandlers(globalThis, _onHandlerBaseline.global);
+                    _restoreOnHandlers(globalThis.document, _onHandlerBaseline.document);
+                }
+                return removed;
+            },
+            writable: true, configurable: true, enumerable: false,
+        });
+        // Seed the baseline on this first execution: it runs as the last
+        // bootstrap, before anything page-authored, so the global namespace
+        // is exactly the engine's. Rust re-marks once more after installing
+        // the post-bootstrap instrumentation. The `internals` purge below
+        // only ever REMOVES keys, so marking before it is safe.
+        globalThis.__markGlobalsBaseline();
+    }
+
     for (const name of internals) {
         [globalThis, globalThis.window].forEach(obj => {
             if (!obj || !(name in obj)) return;
@@ -648,4 +765,5 @@
             }
         });
     }
+
 })(globalThis);

--- a/crates/browser_oxide/src/js_runtime/js/dom_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/dom_bootstrap.js
@@ -3349,4 +3349,40 @@
         configurable: true,
         writable: false,
     });
+
+    // Warm-reuse DOM-registry reaper. Every registry below is module-private
+    // and keyed by (or holding) state that belongs to ONE document, yet it
+    // lives as long as the `JsRuntime`. On the cold path that is exactly the
+    // life of the page, so nothing was ever pruned; on the warm path
+    // (`PagePool` / `Page::navigate_warm`) `replace_dom` swaps the document
+    // underneath them and they accumulate forever. See
+    // `Page::reset_for_reuse`, which calls this.
+    //
+    // `_nodeCache` is doubly wrong across a swap: it is keyed by `nodeId`, and
+    // node IDs restart at zero for the new document, so a surviving entry
+    // hands the NEW page's node the OLD page's wrapper (with the old page's
+    // expandos on it). The `WeakRef` values do not save us — an old wrapper
+    // stays alive as long as any listener closure references it.
+    Object.defineProperty(globalThis, '__resetDomRegistries', {
+        value: function __resetDomRegistries() {
+            _nodeCache.clear();
+            _scrollState.clear();
+            _syncFetchInFlight.clear();
+            // Observers registered by the previous page's scripts. Pages
+            // routinely never call `disconnect()`, so this only shrinks on
+            // reuse — each retained observer pins its callback closure and
+            // every observed target wrapper.
+            _moObservers.length = 0;
+            _appendedIframes.length = 0;
+            _frameRegistry.length = 0;
+            try { globalThis.__ifAppendCount = 0; } catch (_) {}
+            // Re-seed the document wrapper: `_wrapNode` must keep returning
+            // the singleton `_document` for the document node id, which
+            // `replace_dom` preserves.
+            try { _nodeCache.set(ops.op_dom_document_node(), new WeakRef(_document)); } catch (_) {}
+        },
+        writable: true,
+        configurable: true,
+        enumerable: false,
+    });
 })(globalThis);

--- a/crates/browser_oxide/src/js_runtime/js/event_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/event_bootstrap.js
@@ -1,5 +1,4 @@
 ((globalThis) => {
-    const _listeners = new Map(); // nodeId → Map<eventType, [{callback, capture, once}]>
     // ---- Trusted-event authenticity (v0.1.0 behavioral E1) ----------------
     // `isTrusted` MUST be both unforgeable and shaped like a real browser's:
     //   * a GETTER on Event.prototype — NOT an own data property. Scripts
@@ -295,7 +294,40 @@
 
     // --- EventTarget core logic ---
     const _nodeListeners = new Map(); // nodeId → Map<eventType, [{callback, capture, once}]>
-    const _objListeners = new WeakMap(); // object → Map<eventType, [{callback, capture, once}]>
+    let _objListeners = new WeakMap(); // object → Map<eventType, [{callback, capture, once}]>
+
+    // Warm-reuse listener reaper — the events-side analogue of
+    // `timer_bootstrap.js`'s `__cancelAllTimers()`. A pooled `Page`
+    // (`PagePool` / `Page::navigate_warm`) keeps ONE `JsRuntime` alive across
+    // navigations, so both registries above outlive the document they were
+    // populated for. Two distinct failures follow:
+    //
+    //   * Leak. `_objListeners` is keyed by target *object*; listeners a page
+    //     attaches to `window`/`globalThis` (analytics, scroll handlers, …)
+    //     are keyed against the one global that is never collected for the
+    //     life of the isolate, so those callbacks — and every closure
+    //     variable they capture, which can be the page's whole object graph —
+    //     are retained forever. `_nodeListeners` is worse: it is a *strong*
+    //     Map that is never pruned at all. Measured at ~10 MB/page of live
+    //     (non-GC-able) V8 heap on real product pages, unbounded.
+    //   * Cross-page misfire. `_nodeListeners` is keyed by `nodeId`, and node
+    //     IDs restart from zero when `replace_dom` swaps the document. The
+    //     previous page's handler for node 42 therefore fires on the *new*
+    //     page's node 42.
+    //
+    // Called from `Page::reset_for_reuse` alongside `__cancelAllTimers()`.
+    // Non-enumerable so it does not widen `Object.getOwnPropertyNames(window)`.
+    Object.defineProperty(globalThis, '__cancelAllListeners', {
+        value: function __cancelAllListeners() {
+            _nodeListeners.clear();
+            // Reassign rather than clear: WeakMap has no `clear()`, and the
+            // whole point is to drop the `window`-keyed entry.
+            _objListeners = new WeakMap();
+        },
+        writable: true,
+        configurable: true,
+        enumerable: false,
+    });
 
     const _getNodeIdOrMinusOne = (globalThis.__browser_oxide && globalThis.__browser_oxide._getNodeId)
         ? globalThis.__browser_oxide._getNodeId

--- a/crates/browser_oxide/src/js_runtime/js/window_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/window_bootstrap.js
@@ -7081,4 +7081,21 @@
     for (let i = 0; i < 5; i++) _defineIframeGetter(i);
 
     Object.defineProperty(globalThis, Symbol.toStringTag, { value: "Window", configurable: true });
+
+    // Warm-reuse custom-element reaper. Both registries hold page-supplied
+    // constructors (and, for `whenDefined`, unresolved promise resolvers)
+    // for the life of the `JsRuntime`, so on a pooled `Page` they retain
+    // every class every previously-loaded document ever defined. Clearing
+    // also fixes a correctness bug: re-`define()`ing a name the *previous*
+    // page had already registered is a no-op today, so the new page's
+    // element class never upgrades. Called by `Page::reset_for_reuse`.
+    Object.defineProperty(globalThis, '__resetCustomElements', {
+        value: function __resetCustomElements() {
+            _customElementsRegistry.clear();
+            _whenDefinedPromises.clear();
+        },
+        writable: true,
+        configurable: true,
+        enumerable: false,
+    });
 })(globalThis);

--- a/crates/browser_oxide/src/js_runtime/mod.rs
+++ b/crates/browser_oxide/src/js_runtime/mod.rs
@@ -130,6 +130,31 @@ impl BrowserJsRuntime {
         self.inner.v8_isolate().cancel_terminate_execution();
     }
 
+    /// V8's `used_heap_size` for this isolate, in bytes.
+    ///
+    /// Intended for monitoring warm reuse: pair with [`Self::collect_garbage`]
+    /// and sample after each navigation. On a healthy pool the value is flat
+    /// across navigations; a monotonic climb means something is retaining the
+    /// previous page (see `Page::reset_for_reuse`).
+    ///
+    /// Note this is V8 heap only — it excludes external/`ArrayBuffer` backing
+    /// stores and everything Rust-side, so it is not process RSS.
+    pub fn v8_heap_used_bytes(&mut self) -> usize {
+        self.inner.v8_isolate().get_heap_statistics().used_heap_size()
+    }
+
+    /// Ask V8 to perform a full garbage collection.
+    ///
+    /// Only meaningful for measurement: call it before
+    /// [`Self::v8_heap_used_bytes`] so the reading reflects *live* (reachable)
+    /// objects rather than not-yet-collected garbage. Without it, heap-growth
+    /// numbers are dominated by GC scheduling noise. Not a correctness tool —
+    /// never call it on a hot path.
+    pub fn collect_garbage(&mut self) {
+        let _guard = IsolateEnterGuard::enter(self.inner.v8_isolate());
+        self.inner.v8_isolate().low_memory_notification();
+    }
+
     /// Execute a JavaScript script and return the string representation of the result.
     ///
     /// Uses V8 directly in a single HandleScope — avoids the overhead of

--- a/crates/browser_oxide/src/page.rs
+++ b/crates/browser_oxide/src/page.rs
@@ -982,6 +982,24 @@ impl Page {
         self.event_loop.execute_script(js)
     }
 
+    /// V8's `used_heap_size` for this page's isolate, in bytes.
+    ///
+    /// Useful for monitoring a [`crate::pool::PagePool`]: sample after each
+    /// navigation and the value should stay flat. A monotonic climb means
+    /// something is retaining the previous document — call
+    /// [`Page::reset_for_reuse`] between navigations. Call
+    /// [`Page::collect_garbage`] first if you want live-heap rather than
+    /// including uncollected garbage.
+    pub fn v8_heap_used_bytes(&mut self) -> usize {
+        self.event_loop.runtime_mut().v8_heap_used_bytes()
+    }
+
+    /// Ask V8 for a full garbage collection. Measurement aid only — see
+    /// [`Page::v8_heap_used_bytes`]. Never call this on a hot path.
+    pub fn collect_garbage(&mut self) {
+        self.event_loop.runtime_mut().collect_garbage();
+    }
+
     /// Run scripts and wait for completion.
     pub async fn evaluate_async(
         &mut self,
@@ -1489,15 +1507,38 @@ impl Page {
     }
 
     /// Reset all cross-navigation JS state on this Page so its V8 isolate
-    /// can be safely reused for a different URL. Called by
-    /// [`Page::navigate_warm`] and [`crate::pool::PagePool::navigate`].
+    /// can be safely reused for a different URL.
     ///
-    /// What gets cleared:
+    /// Call this before pointing a warm `Page` at new content.
+    /// [`Page::navigate_warm`] and [`crate::pool::PagePool`] already do;
+    /// any consumer that hand-rolls page reuse (e.g. calling
+    /// [`Page::reload_html`] on a `Page` it keeps alive) must call it
+    /// itself, otherwise the reapers below never run — every one of them
+    /// used to be wired only to `Page::drop`, so a pooling consumer
+    /// silently lost all of them.
+    ///
+    /// What gets reaped:
     /// - In-flight `setTimeout` / `setInterval` callbacks (via
     ///   `__cancelAllTimers()` generation bump in `timer_bootstrap.js`).
     ///   Without this, the previous page's `humanize.js` 30 pending
     ///   timers + recurring 4 s setInterval would fire on the new DOM
     ///   and dispatch synthetic mouse events into the wrong document.
+    /// - Every registered event listener (`__cancelAllListeners()` in
+    ///   `event_bootstrap.js`). Listeners bound to `window` are keyed
+    ///   against the one object that is never collected for the life of
+    ///   the isolate, so their closures pinned the previous page's whole
+    ///   object graph; node-keyed listeners additionally misfired on the
+    ///   next document, because node IDs restart at zero.
+    /// - DOM-side registries (`__resetDomRegistries()` in
+    ///   `dom_bootstrap.js`): node-wrapper cache, scroll state,
+    ///   MutationObservers, iframe/frame registries.
+    /// - Custom-element definitions (`__resetCustomElements()` in
+    ///   `window_bootstrap.js`).
+    /// - Globals the previous page's scripts hung off `window`
+    ///   (`__resetPageGlobals()` in `cleanup_bootstrap.js`) — everything
+    ///   added since the engine marked its baseline.
+    /// - Workers the page spawned but never `terminate()`d
+    ///   (`drain_owned_workers`), which `Page::drop` also does.
     /// - `_browser_oxide.__pendingNavigation` — spurious value left by the
     ///   `location.href = …` setter inside the previous build.
     /// - `_browser_oxide.__fetchLog` — DevTools-style network log; must
@@ -1509,17 +1550,23 @@ impl Page {
     ///   sensors read them on POST, so stale values would skew detection.
     /// - `globalThis.__jsCookies` — cookie cache snapshot (the real
     ///   source of truth is the HTTP client's jar, re-synced below).
+    /// - `globalThis.__keepLongTimersRefed` — per-navigation challenge
+    ///   flag; left set, it would pin long timers on every later page.
     ///
     /// What stays:
     /// - V8 isolate, bootstrap scripts (`window_bootstrap.js`,
     ///   `dom_bootstrap.js`, …), and the page-instrumentation wrappers
     ///   on `globalThis.fetch` / `document.cookie` / `XMLHttpRequest`.
     ///   These are the expensive bits we're reusing.
-    fn reset_warm_state(&mut self) {
+    pub fn reset_for_reuse(&mut self) {
         let _ = self.event_loop.execute_script(
             r#"(function() {
                 const g = globalThis;
                 try { g.__cancelAllTimers && g.__cancelAllTimers(); } catch (_) {}
+                try { g.__cancelAllListeners && g.__cancelAllListeners(); } catch (_) {}
+                try { g.__resetDomRegistries && g.__resetDomRegistries(); } catch (_) {}
+                try { g.__resetCustomElements && g.__resetCustomElements(); } catch (_) {}
+                try { delete g.__keepLongTimersRefed; } catch (_) {}
                 if (g._browser_oxide) {
                     g._browser_oxide.__pendingNavigation = null;
                     if (Array.isArray(g._browser_oxide.__fetchLog)) {
@@ -1543,6 +1590,11 @@ impl Page {
                     }
                 }
                 if (g.__jsCookies) g.__jsCookies = {};
+                // Last: drop everything the previous page's scripts hung
+                // off `window`. Runs after the buffer resets above so those
+                // engine-owned names are already back to a clean value (they
+                // are baseline-allowlisted, so this does not remove them).
+                try { g.__resetPageGlobals && g.__resetPageGlobals(); } catch (_) {}
             })();"#,
         );
         // Reap Workers the OUTGOING page spawned but never terminated. The
@@ -1559,6 +1611,10 @@ impl Page {
             let mut state = op_state.borrow_mut();
             crate::js_runtime::extensions::worker_ext::drain_owned_workers(&mut state);
         }
+        // Drop the previous document's iframe isolates. Children are newer
+        // isolates than this Page's, so clearing here keeps V8's
+        // reverse-creation-order drop requirement satisfied.
+        self.children.clear();
     }
 
     /// Navigate this *warm* Page to a new URL by reusing its V8 isolate
@@ -1800,8 +1856,8 @@ impl Page {
         // Cancel all in-flight timers from the previous page and clear
         // cross-nav JS buffers BEFORE swapping the DOM, so any straggler
         // callbacks that try to fire don't see a half-installed state.
-        self.reset_warm_state();
-        wmark!("reset_warm_state");
+        self.reset_for_reuse();
+        wmark!("reset_for_reuse");
 
         // Swap DOM (also resets `TimerState` Rust-side).
         self.event_loop.runtime_mut().replace_dom(dom, stylesheets);
@@ -3819,6 +3875,21 @@ impl Page {
             })();"#)
             .ok();
         mark!("install error + fetch/XHR instrumentation");
+
+        // Re-mark the global-namespace baseline now that every engine-owned
+        // global exists — bootstrap's own (marked at the end of
+        // cleanup_bootstrap.js) plus the instrumentation installed just
+        // above, which is install-once and is NOT re-applied on the warm
+        // path. Anything present after this line belongs to the engine;
+        // anything a page adds later is what `Page::reset_for_reuse`
+        // (`__resetPageGlobals`) sweeps. Must run BEFORE the page's own
+        // scripts, which start below.
+        event_loop
+            .execute_script(
+                "globalThis.__markGlobalsBaseline && globalThis.__markGlobalsBaseline();",
+            )
+            .ok();
+        mark!("__markGlobalsBaseline");
 
         // If the initial document is an anti-bot
         // challenge (AWS-WAF / sec-cpt / one of the other vendors), keep all

--- a/crates/browser_oxide/src/pool.rs
+++ b/crates/browser_oxide/src/pool.rs
@@ -45,6 +45,16 @@ impl PagePool {
             // Note: In a real implementation, we might want to check if the
             // page's profile matches the requested one. For now, we'll
             // just reload it with a blank state.
+            //
+            // `reset_for_reuse` FIRST: the reapers it runs (timers,
+            // listeners, DOM registries, custom elements, page globals,
+            // orphan Workers) are all keyed to the outgoing document, and
+            // every one of them was previously wired only to `Page::drop` —
+            // which a pool, by definition, never reaches. Without this the
+            // isolate's live heap grows ~10 MB per acquire, without ceiling.
+            // Callers that reach `acquire` directly get the same treatment
+            // as the `navigate` path.
+            page.reset_for_reuse();
             page.reload_html("<html><head></head><body></body></html>", "about:blank");
             return Ok(page);
         }

--- a/crates/browser_oxide/src/protocol/server.rs
+++ b/crates/browser_oxide/src/protocol/server.rs
@@ -402,6 +402,14 @@ async fn handle_connection(
                         if let Ok(resp) = client.get(&url).await {
                             let html = resp.text();
                             let mut borrow = page.borrow_mut();
+                            // Same warm-reuse contract as `PagePool` (#33):
+                            // this session keeps ONE `Page` alive for its whole
+                            // lifetime, so without an explicit reset the
+                            // previous document's listeners, DOM registries and
+                            // window properties accumulate for as long as the
+                            // client stays connected — and its listeners misfire
+                            // on the new document, since node IDs restart.
+                            borrow.reset_for_reuse();
                             borrow.reload_html(&html, &url);
                             // Re-inject scripts registered via addScriptToEvaluateOnNewDocument
                             for script in &session.scripts_on_new_document {

--- a/crates/browser_oxide/tests/warm_reuse_heap_growth.rs
+++ b/crates/browser_oxide/tests/warm_reuse_heap_growth.rs
@@ -1,0 +1,104 @@
+//! Quantitative regression test for issue #33 — warm reuse leaked V8 heap.
+//!
+//! The functional tests in `warm_reuse_reset.rs` prove specific things are
+//! unbound. This one proves the *aggregate* consequence: that live V8 heap
+//! stays flat across many reuses.
+//!
+//! It is a true A/B of the fix. `reload_html` WITHOUT `reset_for_reuse` is
+//! exactly what 0.1.0's `PagePool::acquire` did, so the `retain` arm
+//! reproduces 0.1.0 behaviour and the `reset` arm is HEAD. Comparing the two
+//! in one build is more meaningful than comparing against a 0.1.0 checkout,
+//! which has no heap-inspection API to measure with in the first place.
+//!
+//! Measurements are taken after `collect_garbage()`, so they reflect *live*
+//! (reachable) objects. That is the whole point: the reporter observed that a
+//! full GC recovered only 1-2% of the growth, which is what identified the
+//! leak as live references rather than deferred garbage.
+
+use browser_oxide::stealth::StealthProfile;
+use browser_oxide::Page;
+
+/// Each load retains ~1 MB behind a `window` listener closure — the exact
+/// shape that leaked, and a signal far above GC noise.
+const LEAKY_DOC: &str = r#"<html><body><script>
+    (function () {
+        const payload = new Array(130000).fill('xxxxxxxx');
+        window.addEventListener('resize', function () { return payload.length; });
+        window.__appState = payload;
+    })();
+</script></body></html>"#;
+
+const ITERATIONS: usize = 25;
+
+/// Returns live heap (bytes) after `ITERATIONS` reloads, sampled at the start
+/// (post-warmup) and at the end.
+async fn run_reuse_loop(reset_between: bool) -> (usize, usize) {
+    let mut page = Page::from_html(LEAKY_DOC, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    // Warm up: let one-off bootstrap allocations settle so the baseline
+    // reading is not dominated by first-load noise.
+    for _ in 0..3 {
+        if reset_between {
+            page.reset_for_reuse();
+        }
+        page.reload_html(LEAKY_DOC, "about:blank");
+    }
+    page.collect_garbage();
+    let start = page.v8_heap_used_bytes();
+
+    for _ in 0..ITERATIONS {
+        if reset_between {
+            page.reset_for_reuse();
+        }
+        page.reload_html(LEAKY_DOC, "about:blank");
+    }
+    page.collect_garbage();
+    let end = page.v8_heap_used_bytes();
+
+    (start, end)
+}
+
+/// With the reset in place, live heap must not grow meaningfully across
+/// reuses. Threshold is deliberately loose (bytes-per-iteration well under the
+/// ~1 MB each document retains) so this asserts "not leaking", not an exact
+/// allocation profile.
+#[tokio::test]
+async fn heap_is_flat_across_warm_reuses() {
+    let (start, end) = run_reuse_loop(true).await;
+    let growth = end.saturating_sub(start);
+    let per_iter = growth / ITERATIONS;
+
+    println!(
+        "with reset:    start={start} end={end} growth={growth} ({per_iter} B/iteration)"
+    );
+
+    assert!(
+        per_iter < 200_000,
+        "live V8 heap grew {per_iter} B per warm reuse (start={start}, end={end}); \
+         each document retains ~1 MB, so this indicates the reset is not \
+         releasing the previous page"
+    );
+}
+
+/// The control arm: without the reset — i.e. 0.1.0's behaviour — the same
+/// workload must leak. If this ever stops leaking, the test above has become
+/// vacuous and is no longer proving anything.
+#[tokio::test]
+async fn heap_grows_without_reset_control_arm() {
+    let (start, end) = run_reuse_loop(false).await;
+    let growth = end.saturating_sub(start);
+    let per_iter = growth / ITERATIONS;
+
+    println!(
+        "without reset: start={start} end={end} growth={growth} ({per_iter} B/iteration)"
+    );
+
+    assert!(
+        per_iter > 200_000,
+        "control arm did not leak ({per_iter} B/iteration) — the A/B test above \
+         is no longer meaningful, because reuse-without-reset is supposed to \
+         reproduce the 0.1.0 leak"
+    );
+}

--- a/crates/browser_oxide/tests/warm_reuse_reset.rs
+++ b/crates/browser_oxide/tests/warm_reuse_reset.rs
@@ -1,0 +1,349 @@
+//! Regression tests for issue #33 — `PagePool` / warm reuse leaked V8 heap.
+//!
+//! The engine's cross-navigation reapers were all wired to `Page::drop`, which
+//! a pool by definition never reaches, and several bootstrap-JS registries are
+//! scoped to the `JsRuntime` rather than to the document. Reusing a `Page`
+//! therefore retained the previous page's listeners, DOM wrappers, custom
+//! elements and window properties — ~10 MB of *live* heap per navigation,
+//! without ceiling.
+//!
+//! These tests assert the observable consequences of that retention are gone
+//! after `Page::reset_for_reuse()`. They deliberately do NOT measure heap size:
+//! `used_heap_size` is GC-timing dependent and would be flaky. Retention is
+//! instead proven by reachability — a listener that still fires, or a global
+//! that still resolves, is a listener/global that is still retained.
+
+use browser_oxide::stealth::StealthProfile;
+use browser_oxide::Page;
+
+const BLANK: &str = "<html><head></head><body></body></html>";
+
+/// Listeners bound to `window` were keyed in a `WeakMap` against the one
+/// object that is never collected for the life of the isolate, so neither the
+/// callback nor anything its closure captured could ever be released.
+#[tokio::test]
+async fn reset_unbinds_window_listeners() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            window.addEventListener('resize', function () {
+                globalThis.__hits = (globalThis.__hits || 0) + 1;
+            });
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    // Sanity: the listener is live before the reset, otherwise the assertion
+    // below would pass for the wrong reason.
+    page.evaluate("window.dispatchEvent(new Event('resize'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("String(globalThis.__hits)").unwrap(),
+        "1",
+        "listener should fire before reset — test is not exercising anything otherwise"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    page.evaluate("window.dispatchEvent(new Event('resize'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("typeof globalThis.__hits").unwrap(),
+        "undefined",
+        "previous page's window listener still fired after reset"
+    );
+}
+
+/// `_nodeListeners` is a strong `Map` keyed by `nodeId`, and node IDs restart
+/// at zero when `replace_dom` swaps the document. So this was both a leak and
+/// a correctness bug: the old page's handler for node 42 fired on the *new*
+/// page's node 42.
+#[tokio::test]
+async fn reset_unbinds_node_listeners_across_documents() {
+    let doc = r#"<html><body><div id="a"></div></body></html>"#;
+    let mut page = Page::from_html(
+        r#"<html><body><div id="a"></div><script>
+            document.querySelector('#a').addEventListener('click', function () {
+                globalThis.__hits = (globalThis.__hits || 0) + 1;
+            });
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    page.evaluate("document.querySelector('#a').dispatchEvent(new Event('click'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("String(globalThis.__hits)").unwrap(),
+        "1",
+        "listener should fire before reset"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(doc, "about:blank");
+
+    // Same markup ⇒ the new `#a` gets the same nodeId the old one had.
+    page.evaluate("document.querySelector('#a').dispatchEvent(new Event('click'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("typeof globalThis.__hits").unwrap(),
+        "undefined",
+        "previous document's node listener fired on the new document's node"
+    );
+}
+
+/// Properties page scripts hang off `window` outlived the navigation, because
+/// `globalThis` is the same object for the life of the `JsRuntime`. A real
+/// browser gives each navigation a fresh global.
+#[tokio::test]
+async fn reset_clears_page_authored_globals() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            window.__appState = { rows: new Array(1000).fill('x') };
+            window.onscroll = function () {};
+            globalThis.__singleton = { self: null };
+            globalThis.__singleton.self = globalThis.__singleton;
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(page.evaluate("typeof window.__appState").unwrap(), "object");
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_eq!(
+        page.evaluate("typeof window.__appState").unwrap(),
+        "undefined",
+        "page-authored global survived reset"
+    );
+    assert_eq!(
+        page.evaluate("typeof globalThis.__singleton").unwrap(),
+        "undefined",
+        "page-authored global survived reset"
+    );
+    assert_eq!(
+        page.evaluate("String(window.onscroll)").unwrap(),
+        "null",
+        "page-authored on* handler survived reset"
+    );
+}
+
+/// `on*` handlers are a distinct case from ordinary page globals: `onscroll`,
+/// `onclick` and friends already exist as own properties at bootstrap, so a
+/// page assigning to one mutates a *baseline* key rather than adding one. The
+/// key-set diff cannot see that, so the value is swept separately. `document`
+/// needs the same treatment — it is a singleton that survives `replace_dom`.
+#[tokio::test]
+async fn reset_clears_document_on_handlers() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            document.onclick = function () { globalThis.__hits = 1; };
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        page.evaluate("typeof document.onclick").unwrap(),
+        "function",
+        "handler should be set before reset"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_ne!(
+        page.evaluate("typeof document.onclick").unwrap(),
+        "function",
+        "page-authored document.on* handler survived reset"
+    );
+}
+
+/// The `on*` sweep must not be a blanket wipe: the engine installs
+/// `window.onerror` as its script-error instrumentation exactly once, on the
+/// cold build, and never re-installs it on the warm path. Nulling it would
+/// silently disable error capture for every pooled page after the first.
+#[tokio::test]
+async fn reset_preserves_engine_installed_on_handlers() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    // Stand in for the engine's own install, then re-mark the baseline the
+    // same way the cold build does after installing its instrumentation.
+    page.evaluate(
+        "window.onerror = function engineHandler() { return true; }; \
+         globalThis.__markGlobalsBaseline(); 'ok'",
+    )
+    .unwrap();
+
+    // A page then clobbers it with its own handler.
+    page.evaluate("window.onerror = function pageHandler() {}; 'ok'")
+        .unwrap();
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_eq!(
+        page.evaluate("window.onerror && window.onerror.name").unwrap(),
+        "engineHandler",
+        "reset did not restore the engine's own on* handler — either it was \
+         nulled (breaking instrumentation) or the page's was left in place"
+    );
+}
+
+/// Guard against the global sweep being too aggressive: it must diff against
+/// the engine's own baseline, not wipe the namespace. If this fails, the
+/// bootstrap is being damaged and every later navigation is broken.
+#[tokio::test]
+async fn reset_preserves_engine_globals() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    for expr in [
+        "typeof document",
+        "typeof window",
+        "typeof navigator",
+        "typeof location",
+        "typeof fetch",
+        "typeof setTimeout",
+        "typeof XMLHttpRequest",
+        "typeof MutationObserver",
+        "typeof customElements",
+        "typeof Event",
+    ] {
+        let got = page.evaluate(expr).unwrap();
+        assert_ne!(
+            got, "undefined",
+            "reset stripped an engine global: {expr} became undefined"
+        );
+    }
+
+    // The DOM must still be usable, not merely present.
+    page.reload_html(
+        r#"<html><body><p id="p">hi</p></body></html>"#,
+        "about:blank",
+    );
+    assert_eq!(
+        page.evaluate("document.querySelector('#p').textContent")
+            .unwrap(),
+        "hi",
+        "DOM unusable after reset"
+    );
+}
+
+/// `_customElementsRegistry` retained every class every previously-loaded
+/// document defined. That is a leak, and it silently broke the next page:
+/// re-`define()`ing a name the previous page had registered was a no-op, so
+/// the new page's element never upgraded.
+#[tokio::test]
+async fn reset_allows_custom_element_redefinition() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            class First extends HTMLElement {}
+            customElements.define('x-widget', First);
+            globalThis.__which = 'first';
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        page.evaluate("typeof customElements.get('x-widget')")
+            .unwrap(),
+        "function"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_eq!(
+        page.evaluate("typeof customElements.get('x-widget')")
+            .unwrap(),
+        "undefined",
+        "previous page's custom element definition survived reset"
+    );
+
+    // And the name is free again for the next document.
+    page.evaluate(
+        "class Second extends HTMLElement {}; customElements.define('x-widget', Second); 'ok'",
+    )
+    .unwrap();
+    assert_eq!(
+        page.evaluate("customElements.get('x-widget').name")
+            .unwrap(),
+        "Second",
+        "re-defining a name the previous page used did not take effect"
+    );
+}
+
+/// Timers must still work after a reset — `__cancelAllTimers()` bumps a
+/// generation counter, and a bug there would silently kill every timer on
+/// every pooled page after the first.
+#[tokio::test]
+async fn reset_leaves_timers_functional() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    page.evaluate_async(
+        "globalThis.__fired = false; setTimeout(() => { globalThis.__fired = true; }, 0); 'ok'",
+        std::time::Duration::from_millis(500),
+    )
+    .await
+    .ok();
+
+    assert_eq!(
+        page.evaluate("String(globalThis.__fired)").unwrap(),
+        "true",
+        "setTimeout stopped firing after a reset"
+    );
+}
+
+/// Repeated reuse must stay clean — a reset that only works once would leave
+/// the pool leaking from the second navigation onward.
+#[tokio::test]
+async fn reset_is_idempotent_across_many_reuses() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    for i in 0..10 {
+        page.evaluate(&format!(
+            "window.__leak{i} = new Array(100).fill('x'); \
+             window.addEventListener('resize', function () {{ globalThis.__hits = 1; }}); 'ok'"
+        ))
+        .unwrap();
+
+        page.reset_for_reuse();
+        page.reload_html(BLANK, "about:blank");
+
+        assert_eq!(
+            page.evaluate(&format!("typeof window.__leak{i}")).unwrap(),
+            "undefined",
+            "global from reuse #{i} survived"
+        );
+        page.evaluate("window.dispatchEvent(new Event('resize'))")
+            .unwrap();
+        assert_eq!(
+            page.evaluate("typeof globalThis.__hits").unwrap(),
+            "undefined",
+            "listener from reuse #{i} survived"
+        );
+    }
+}

--- a/crates/browser_oxide_py/Cargo.toml
+++ b/crates/browser_oxide_py/Cargo.toml
@@ -11,7 +11,7 @@
 
 [package]
 name = "browser_oxide_py"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #33.

## Root cause

The reporter's diagnosis was right about the mechanism but incomplete about the sources. The leak isn't one thing: **every reaper the engine had was wired only to `Page::drop`** — which a pool by definition never reaches — and several bootstrap-JS registries are scoped to the `JsRuntime` rather than to the document. On the cold path that distinction never mattered, because the runtime *is* the page. On the warm path `replace_dom` swaps the document underneath them and they accumulate forever.

Everything below was unpruned on reuse:

| Registry | File | Why it retains |
|---|---|---|
| `_objListeners` | `event_bootstrap.js:298` | `WeakMap` keyed by target object — but `window`-bound listeners are keyed against the one object that is never collected for the life of the isolate. Their closures pin the page's whole object graph. |
| `_nodeListeners` | `event_bootstrap.js:297` | **Strong** `Map`, never pruned at all. The dominant source. |
| `_nodeCache`, `_scrollState` | `dom_bootstrap.js:5-6` | Strong `Map`s keyed by `nodeId`. The `WeakRef` values don't help — an old wrapper stays alive as long as any listener closure references it. |
| `_moObservers` | `dom_bootstrap.js:1926` | Only shrinks on `disconnect()`, which pages rarely call. |
| `_appendedIframes`, `_frameRegistry` | `dom_bootstrap.js:2034, 2395` | Iframe element wrappers and child realm windows. |
| `_customElementsRegistry`, `_whenDefinedPromises` | `window_bootstrap.js:4579-4580` | Page-supplied constructors, forever. |
| `globalThis` properties | — | `window.__APP_STATE = …`, framework singletons. The reporter suspected this; it's real. |
| `on*` handler **values** | — | `window.onscroll = fn`. These already exist as own properties at bootstrap, so a key-set diff cannot see the assignment. |

Confirming the two things the report ruled out: `__cancelAllTimers()` is present on the warm path, and `drain_owned_workers` was **already** called from `reset_warm_state` on `main` (page.rs:1560) — so suggestion #2 was partly landed already.

## Changes

New JS reset hooks, all non-enumerable so they don't widen `Object.getOwnPropertyNames(window)`:

- `__cancelAllListeners()` — `event_bootstrap.js` (the ticket's suggestion #1)
- `__resetDomRegistries()` — `dom_bootstrap.js`
- `__resetCustomElements()` — `window_bootstrap.js`
- `__markGlobalsBaseline()` / `__resetPageGlobals()` — `cleanup_bootstrap.js`

Bundled behind a new public **`Page::reset_for_reuse()`** (the ticket's suggestion #2). Called by `PagePool::acquire`, `Page::navigate_warm`, and the CDP protocol server.

I did **not** take suggestion #3 (`create_realm()` per reuse) — it would discard most of the pooling benefit, and the numbers below show it isn't needed.

### The globals sweep is a diff, not a wipe

`__resetPageGlobals()` deletes only keys added since a baseline the engine marks *after* installing its post-bootstrap instrumentation and *before* any page script runs. `on*` handlers get value-level treatment: values are snapshotted at baseline and restored, which clears `window.onscroll = fn` while **preserving the engine's own `window.onerror`** instrumentation — that one is installed once on the cold build and never re-applied on the warm path, so a blanket wipe would have silently disabled error capture for every pooled page after the first. There's a dedicated test for exactly this.

## Evidence: A/B on live heap

`reload_html` *without* `reset_for_reuse` is precisely what 0.1.0's `PagePool::acquire` did, so the control arm reproduces 0.1.0 behaviour and the other arm is HEAD. Comparing them in one build is more meaningful than comparing against a 0.1.0 checkout, which has no heap-inspection API to measure with in the first place.

25 warm reuses of a document retaining ~1 MB behind a `window` listener closure. **Measured after a forced full GC, so these are live/reachable objects** — which is the crux: the reporter observed a full GC recovered only 1–2%, identifying the growth as live references rather than deferred garbage.

| Arm | Live heap growth per reuse |
|---|---|
| Without reset (= 0.1.0) | **1,040,662 B** (~1.04 MB) |
| With reset (this PR) | **468 B** |

≈2,200× reduction; the control arm recovers essentially the full ~1 MB the document retains, matching the reporter's ~10 MB/page on real product pages scaled to this synthetic doc.

Both arms are committed as `tests/warm_reuse_heap_growth.rs`. The control arm asserts it *does* leak — if it ever stops, the positive test has gone vacuous and should fail loudly rather than silently prove nothing.

## Correctness bugs fixed by the same change

Two of these are not memory issues and are worth calling out separately:

1. **The previous page's handlers fired on the new document.** `_nodeListeners` and `_nodeCache` are keyed by `nodeId`, and node IDs restart at zero when `replace_dom` swaps the document — so the old page's listener for node 42 fired on the new page's node 42, and the new page's node could be handed the old page's wrapper with its expandos.
2. **Custom elements could not be re-defined across a warm navigation.** `customElements.define()` for a name the *previous* page registered was a silent no-op, so the new page's class never upgraded.
3. `__keepLongTimersRefed` stayed set after a challenge page, pinning long timers on every later navigation of that `Page`.
4. **The CDP protocol server had the identical leak.** `Page.navigate` swaps the document via `reload_html` on a `Page` the session keeps alive for its whole lifetime.

## Also added

`Page::v8_heap_used_bytes()` and `Page::collect_garbage()` (also on `BrowserJsRuntime`), so operators can verify pool health directly — sample after each navigation and a healthy pool stays flat. The A/B test is built on them.

## Removed

Dead `_listeners` registry in `event_bootstrap.js` — declared, never read.

## Testing

11 new tests across two files, all passing locally (release, `--test-threads=1`):

```
tests/warm_reuse_reset.rs ......... 9 passed
tests/warm_reuse_heap_growth.rs ... 2 passed
```

Covering: window-listener unbinding, node-listener cross-document misfire, page-global sweep, `document.on*` handlers, **engine `on*` handlers preserved**, custom-element redefinition, timers still functional after reset, idempotency across 10 reuses, a guard that the sweep does *not* strip engine globals (`document`/`fetch`/`setTimeout`/… still defined and the DOM still usable), plus both A/B arms.

`cargo clippy --lib -- -D warnings` and `cargo fmt --all --check` are clean.

> Note: `tests/debug_blocked.rs` has a **pre-existing** clippy failure (`redundant reference in println!`) under newer clippy, untouched by this PR — it will trip `--all-targets` independently of these changes.

## Bindings

Checked: neither `browser_oxide_py` nor `browser_oxide_mcp` exposes `PagePool` or warm reuse, so there is no binding surface to propagate this to. The one *other* in-tree warm-reuse consumer was the CDP server, fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptn8MHsL8gwcsszwquKrfu
