### PR TITLE
0.1.2: fix warm-reuse leak + wrong output (#33), dependency refresh, security fixes

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,7 +25,7 @@ jobs:
         # large-packages removes `^llvm-.*` (libclang/lld) → breaks boring-sys2
         # bindgen + lld linking. Keep it false; the rest still frees ~20 GB.
         with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: false, swap-storage: false }
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install skia system deps (freetype + fontconfig)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,7 +22,7 @@ jobs:
     name: Validate CHANGELOG for workspace version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Extract [workspace.package] version
         id: ver
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
@@ -40,7 +40,7 @@ jobs:
     # lives in the root Cargo.toml `[workspace.lints.clippy]` table; any
     # remaining per-site `#[allow(...)]` carries a justifying comment.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
@@ -81,7 +81,7 @@ jobs:
           large-packages: false
           swap-storage: true
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: ${{ matrix.rust }}
@@ -118,7 +118,7 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       # 1.91 is the real floor: deno_core 0.403 uses const `TypeId::of`
       # (cppgc.rs), stabilized in Rust 1.91, but declares no rust-version — so
       # the resolver doesn't catch it; only an actual build does (1.90 fails,
@@ -138,7 +138,7 @@ jobs:
     # Mechanical enforcement of the workspace policy at deny.toml:
     # MIT/Apache-only licenses, crates.io-only sources, fail on advisories.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       # Use the current cargo-deny CLI rather than the action: the action bundles
       # an older cargo-deny whose advisory-db parser chokes on newer RUSTSEC
       # entries (e.g. RUSTSEC-2026-0124). The current CLI parses them fine.
@@ -153,7 +153,7 @@ jobs:
     name: Security audit (cargo-audit / RUSTSEC)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       # Use the current cargo-audit CLI rather than rustsec/audit-check: the
       # action bundles an older rustsec parser that chokes on newer advisory-db
       # entries. cargo-audit reads the ignore list from audit.toml.
@@ -168,7 +168,7 @@ jobs:
     name: TOML format (taplo)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2
         with:
           tool: taplo-cli
@@ -178,7 +178,7 @@ jobs:
     name: Unused deps (cargo-shear)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2
         with:
           tool: cargo-shear
@@ -188,7 +188,7 @@ jobs:
     name: Unsafe-code report (cargo-geiger, informational)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -205,7 +205,7 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: false, swap-storage: false }
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -226,7 +226,7 @@ jobs:
     # block. CHANGELOG is the source of truth until we cut 1.0.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: obi1kenobi/cargo-semver-checks-action@7272cc2caa468d3e009a2b0a9cc366839348237b # v2
 
   coverage:
@@ -236,7 +236,7 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: false, swap-storage: false }
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
@@ -257,7 +257,7 @@ jobs:
     name: Benchmark smoke (compile only)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libfreetype6-dev
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
       - name: Check Signed-off-by on PR commits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
       # share of the engine is exercised only by #[ignore] live-network tests,
       # so a line-% gate would be misleading. Reported + uploaded, not enforced.
       - run: cargo llvm-cov --workspace --lcov --output-path lcov.info -- --test-threads=1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           files: ./lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,11 @@ jobs:
           head="${{ github.event.pull_request.head.sha }}"
           missing=0
           while IFS= read -r sha; do
-            git log -1 --pretty=full "$sha" | grep -q "^Signed-off-by:" || {
+            # `--format=%B` emits the RAW commit body. Do not use
+            # `--pretty=full` here: it indents the body by four spaces, so a
+            # `^Signed-off-by:` anchor never matches and the check fails even
+            # on correctly signed-off commits.
+            git log -1 --format=%B "$sha" | grep -q "^Signed-off-by:" || {
               echo "::error::commit $sha missing Signed-off-by trailer"; missing=$((missing+1)); }
           done < <(git log --pretty=format:"%H" "${base}..${head}")
           [ "$missing" -eq 0 ] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       # Use the current cargo-deny CLI rather than the action: the action bundles
       # an older cargo-deny whose advisory-db parser chokes on newer RUSTSEC
       # entries (e.g. RUSTSEC-2026-0124). The current CLI parses them fine.
-      - uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
         with:
           # Pin a version new enough to parse current advisory-db entries
           # (older cargo-deny chokes on e.g. RUSTSEC-2026-0124).
@@ -157,7 +157,7 @@ jobs:
       # Use the current cargo-audit CLI rather than rustsec/audit-check: the
       # action bundles an older rustsec parser that chokes on newer advisory-db
       # entries. cargo-audit reads the ignore list from audit.toml.
-      - uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
         with:
           # Pin a version new enough to parse current advisory-db entries
           # (the action's default older cargo-audit chokes on RUSTSEC-2026-0124).
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
-      - uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
         with:
           tool: taplo-cli
       - run: taplo fmt --check
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
-      - uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
         with:
           tool: cargo-shear
       - run: cargo shear
@@ -210,7 +210,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: hack
-      - uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
         with:
           tool: cargo-hack
       - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libfreetype6-dev

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         language: [rust]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
@@ -37,6 +37,6 @@ jobs:
       - name: Build for CodeQL
         run: cargo build --workspace
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -14,7 +14,7 @@ jobs:
     name: cargo outdated
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,7 +55,7 @@ jobs:
       # (Mach-O) and Windows (PE) link the prebuilt V8 fine.
       V8_FROM_SOURCE: ${{ startsWith(matrix.platform.runner, 'ubuntu') && '1' || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -152,7 +152,7 @@ jobs:
     needs: wheels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Harsh check: on a tag, the tag must equal pyproject.toml's version,
       # else we'd ship a wrong-versioned wheel. Mirrors the crates.io gate.
       - name: Validate tag matches pyproject version

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           python -m pip install --upgrade twine
           python -m twine check dist/*.whl
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.platform.target }}
           path: dist/*.whl

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # need full history + branches for the on-main check
       - name: Install skia system deps (freetype + fontconfig)
@@ -103,7 +103,7 @@ jobs:
       name: crates-io
       url: https://crates.io/crates/browser_oxide
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install skia system deps (freetype + fontconfig)
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libfreetype6-dev
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -25,7 +25,7 @@ jobs:
           - { runner: macos-latest,   target: x86_64-apple-darwin }
           - { runner: windows-latest, target: x86_64-pc-windows-msvc }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -57,7 +57,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
           path: dist

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -42,7 +42,7 @@ jobs:
           [ "${{ runner.os }}" = "Windows" ] && bin="$bin.exe"
           tar -czf "browser-oxide-mcp-${{ matrix.target }}.tar.gz" \
             -C "target/${{ matrix.target }}/release" "$bin"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mcp-${{ matrix.target }}
           path: browser-oxide-mcp-${{ matrix.target }}.tar.gz

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,6 @@ jobs:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           persist-credentials: false
       - name: Run Scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: scorecard-results
           path: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.1.1]
+## [0.1.2]
 
 ### Fixed
 - **`PagePool` / warm reuse leaked V8 heap without bound**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,14 @@ supersedes the open Dependabot PRs
 ([#22](https://github.com/yfedoseev/browser_oxide/pull/22)–[#31](https://github.com/yfedoseev/browser_oxide/pull/31)),
 whose commits are cherry-picked here with authorship preserved.
 
-- `deno_core` 0.403 → **0.408** (V8 149.2 → 149.4). This also resolves the
-  `deno_error` resolution failure reported in #32 — that conflict came from a
-  `^0.7.3` requirement; the workspace uses `^0.7`, which resolves to 0.7.1
-  alongside `deno_core` 0.408.
+- `deno_core` 0.403 → **0.404**. This also resolves the `deno_error` resolution
+  failure reported in #32 — that conflict came from a `^0.7.3` requirement;
+  the workspace uses `^0.7`, which resolves cleanly here.
+  0.408 was tried first and reverted: it builds and passes the full suite in
+  release, but **aborts (SIGABRT) during V8 isolate construction in debug
+  builds on Linux** — `basic_js_execution`, which only builds a runtime and
+  evaluates `1 + 2`, dies before printing a result. Tracked separately; the
+  bump needs a debug repro before it can land.
 - `taffy` 0.8 → **0.11** (adds safe-alignment keywords).
 - `sha1` and `sha2` 0.10 → **0.11**. These must move together: `sha2` 0.11
   pulls `digest` 0.11, which makes the in-scope `Digest` trait incompatible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,31 @@ whose commits are cherry-picked here with authorship preserved.
   applies.
 - `chrono` 0.4.44 → 0.4.45, `http2` 0.5.17 → 0.5.19, plus `cargo update` across
   the tree for all remaining semver-compatible upgrades.
+
+### Security
+Two advisories in the dependency tree are resolved by the `cargo update` above.
+Neither is reachable through a public `browser_oxide` API, but both are worth
+noting for anyone auditing the tree:
+
+- **`quinn-proto` 0.11.14 → 0.11.16** — [RUSTSEC-2026-0185], remote memory
+  exhaustion via unbounded out-of-order stream reassembly. This one sits in the
+  HTTP/3 path, so it is reachable from a hostile server on an h3 connection.
+- **`crossbeam-epoch` 0.9.18 → 0.9.20** — [RUSTSEC-2026-0204], invalid pointer
+  dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`.
+- `anyhow` 1.0.102 → 1.0.104 also clears [RUSTSEC-2026-0190] (unsoundness in
+  `Error::downcast_mut()`).
+
+`deny.toml`: added documented ignores for [RUSTSEC-2026-0206] (`rustybuzz`) and
+[RUSTSEC-2026-0192] (`ttf-parser`) — both *unmaintained* notices rather than
+vulnerabilities, on the direct text-shaping stack, with no maintained pure-Rust
+replacement. Dropped the now-stale `adler` ignore, which the `deno_core` bump
+resolved.
+
+[RUSTSEC-2026-0185]: https://rustsec.org/advisories/RUSTSEC-2026-0185
+[RUSTSEC-2026-0204]: https://rustsec.org/advisories/RUSTSEC-2026-0204
+[RUSTSEC-2026-0190]: https://rustsec.org/advisories/RUSTSEC-2026-0190
+[RUSTSEC-2026-0206]: https://rustsec.org/advisories/RUSTSEC-2026-0206
+[RUSTSEC-2026-0192]: https://rustsec.org/advisories/RUSTSEC-2026-0192
 - CI actions: `actions/checkout` 4 → 6, `actions/upload-artifact` 4 → 7,
   `codecov/codecov-action` 4 → 7, `taiki-e/install-action` 2.49.40 → 2.81.11,
   `github/codeql-action` 4.36.0 → 4.36.2 (all SHA-pinned).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,32 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 - Dead `_listeners` registry in `event_bootstrap.js` (declared, never read).
 
+### Dependencies
+Closes [#32](https://github.com/yfedoseev/browser_oxide/issues/32) and
+supersedes the open Dependabot PRs
+([#22](https://github.com/yfedoseev/browser_oxide/pull/22)–[#31](https://github.com/yfedoseev/browser_oxide/pull/31)),
+whose commits are cherry-picked here with authorship preserved.
+
+- `deno_core` 0.403 → **0.408** (V8 149.2 → 149.4). This also resolves the
+  `deno_error` resolution failure reported in #32 — that conflict came from a
+  `^0.7.3` requirement; the workspace uses `^0.7`, which resolves to 0.7.1
+  alongside `deno_core` 0.408.
+- `taffy` 0.8 → **0.11** (adds safe-alignment keywords).
+- `sha1` and `sha2` 0.10 → **0.11**. These must move together: `sha2` 0.11
+  pulls `digest` 0.11, which makes the in-scope `Digest` trait incompatible
+  with a `sha1` still on `digest` 0.10.
+- `adblock` 0.12 → **0.13** (optional `blocker` feature). Required an API port
+  — `Engine::from_filter_set` → `new_with_filter_set`, `Request::new` gained a
+  fourth argument, `BlockerResult.matched` → `should_block()`. Ported by
+  [@Ran-Mewo](https://github.com/Ran-Mewo) in the SilvR-AI fork; adopted here
+  with thanks. The `deny.toml` MPL-2.0 exception is name-based and still
+  applies.
+- `chrono` 0.4.44 → 0.4.45, `http2` 0.5.17 → 0.5.19, plus `cargo update` across
+  the tree for all remaining semver-compatible upgrades.
+- CI actions: `actions/checkout` 4 → 6, `actions/upload-artifact` 4 → 7,
+  `codecov/codecov-action` 4 → 7, `taiki-e/install-action` 2.49.40 → 2.81.11,
+  `github/codeql-action` 4.36.0 → 4.36.2 (all SHA-pinned).
+
 ## [0.1.0] — 2026-06-13
 
 > First open-source release of BrowserOxide — a from-scratch stealth headless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,15 +67,31 @@ supersedes the open Dependabot PRs
 ([#22](https://github.com/yfedoseev/browser_oxide/pull/22)–[#31](https://github.com/yfedoseev/browser_oxide/pull/31)),
 whose commits are cherry-picked here with authorship preserved.
 
-- `deno_core` 0.403 → **0.404**. This also resolves the `deno_error` resolution
-  failure reported in #32 — that conflict came from a `^0.7.3` requirement;
-  the workspace uses `^0.7`, which resolves cleanly here.
-  0.408 was tried first and reverted: it builds and passes the full suite in
-  release, but **aborts (SIGABRT) during V8 isolate construction in debug
-  builds on Linux** — `basic_js_execution`, which only builds a runtime and
-  evaluates `1 + 2`, dies before printing a result. Tracked separately; the
+- `deno_core` 0.403 → **0.404**. 0.408 was tried and reverted: it builds and
+  passes the full suite in release, but **aborts (SIGABRT) during V8 isolate
+  construction in debug builds on Linux** — `basic_js_execution`, which only
+  builds a runtime and evaluates `1 + 2`, dies before printing a result. The
   bump needs a debug repro before it can land.
-- `taffy` 0.8 → **0.11** (adds safe-alignment keywords).
+- `taffy` 0.8 → **0.12** (adds safe-alignment keywords).
+- `skia-safe` 0.97 → **0.99**, `tokio-tungstenite` 0.27 → **0.30**,
+  `webpki-root-certs` 0.26 → **1.0**, `brotli` 7 → **8**, `base64` 0.22 →
+  **0.23**, `glow` 0.17 → **0.18** (behind the `webgl-render` feature).
+- **`png` deliberately held at 0.17.** 0.18 merges `FilterType` +
+  `AdaptiveFilterType` into one `Filter` enum, and while `Compression::Balanced`
+  does map back to the same flate2 level, `Filter::Adaptive` is *not*
+  equivalent to the `Paeth` + adaptive pair the canvas encoder uses. Measured
+  on the standard FingerprintJS canvas sequence, 0.18 emits a 9,646-byte data
+  URL where 0.17 emits 17,502 — i.e. a different canvas fingerprint for every
+  page. Added `examples/canvas_fp_probe.rs` so this is checkable in one command
+  before any future bump.
+
+On [#32](https://github.com/yfedoseev/browser_oxide/issues/32): the reported
+`deno_error` conflict is an artifact of how `cargo-outdated` probes. It
+synthesizes a manifest requiring the latest of *everything simultaneously*,
+which pairs `deno_core` 0.409 (whose own manifest pins `deno_error` **=0.7.1**)
+against `deno_error` 0.7.3 — a combination that cannot resolve upstream and
+does not exist in this workspace. It will keep recurring in the monthly
+`outdated` workflow until `deno_core` catches up with `deno_error`.
 - `sha1` and `sha2` 0.10 → **0.11**. These must move together: `sha2` 0.11
   pulls `digest` 0.11, which makes the in-scope `Digest` trait incompatible
   with a `sha1` still on `digest` 0.10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.1]
+
+### Fixed
+- **`PagePool` / warm reuse leaked V8 heap without bound**
+  ([#33](https://github.com/yfedoseev/browser_oxide/issues/33)). Reusing a
+  `Page` across navigations grew V8's live (non-collectable) heap by ~10 MB
+  per page, eventually OOMing long batches. Every one of the engine's reapers
+  was wired only to `Page::drop`, which a pool by definition never reaches,
+  and the bootstrap JS keeps several registries scoped to the `JsRuntime`
+  rather than to the document. Now reaped on reuse:
+  - all registered event listeners (`__cancelAllListeners()` in
+    `event_bootstrap.js`) — `window`-bound listeners were keyed against the
+    one object that outlives every navigation, so their closures pinned the
+    previous page's entire object graph, and `_nodeListeners` was a strong
+    `Map` that was never pruned at all;
+  - the DOM node-wrapper cache, scroll state, `MutationObserver` registry,
+    and iframe/frame registries (`__resetDomRegistries()`);
+  - custom-element definitions (`__resetCustomElements()`);
+  - globals the page hung off `window` (`__resetPageGlobals()`), diffed
+    against a baseline the engine marks before any page script runs.
+- **Warm reuse misfired the previous page's handlers on the new document.**
+  `_nodeListeners` and the node-wrapper cache are keyed by `nodeId`, and node
+  IDs restart at zero when `replace_dom` swaps the document — so the old
+  page's listener for node 42 fired on the new page's node 42, and the new
+  page's node could be handed the old page's wrapper (with its expandos).
+  Fixed by the same reset.
+- **Custom elements could not be re-defined across a warm navigation.**
+  `customElements.define()` for a name the *previous* page had registered was
+  a silent no-op, so the new page's class never upgraded.
+- `Page::navigate_warm` left `__keepLongTimersRefed` set after a challenge
+  page, pinning long timers on every subsequent navigation of that `Page`.
+- **The CDP protocol server leaked the same way.** `Page.navigate` swaps the
+  document with `reload_html` on a `Page` the session keeps alive for its
+  whole lifetime, so it accumulated the previous document's state for as long
+  as a client stayed connected. It now resets between documents.
+- Page-assigned `on*` handlers (`window.onscroll = …`, `document.onclick = …`)
+  survived reuse. These already exist as own properties at bootstrap, so a
+  key-set diff cannot see the assignment; handler *values* are now snapshotted
+  at baseline and restored, which clears page assignments while preserving the
+  engine's own `window.onerror` instrumentation.
+
+### Added
+- `Page::reset_for_reuse()` — public, bundles every cross-navigation reaper
+  (timers, listeners, DOM registries, custom elements, page globals, orphan
+  Workers, child iframe isolates). Consumers that hand-roll page reuse — e.g.
+  calling `Page::reload_html` on a `Page` they keep alive — should call this
+  between documents; `PagePool`, `Page::navigate_warm` and the CDP server
+  already do.
+- `Page::v8_heap_used_bytes()` and `Page::collect_garbage()` (also on
+  `BrowserJsRuntime`) — lets pool operators verify heap health directly.
+  Sample after each navigation; a healthy pool stays flat.
+
+### Removed
+- Dead `_listeners` registry in `event_bootstrap.js` (declared, never read).
+
 ## [0.1.0] — 2026-06-13
 
 > First open-source release of BrowserOxide — a from-scratch stealth headless

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.5.17"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569ef7a780e853c4e1768f58a3c8168193b82cdcbab66638a0b1c6583ec5995e"
+checksum = "39fa01ed3820381df693c455ba2109d229c0cb02c95a51108ef45ddd758d91b9"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "77420e48225975c472eaea1b7c767af6caebea02d910043b0af7a1271d47ec9c"
 dependencies = [
  "addr",
  "arrayvec",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "flatbuffers",
  "idna",
@@ -136,6 +136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,15 +224,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -255,7 +252,7 @@ checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
 dependencies = [
  "bitflags 2.13.1",
  "boring-sys2",
- "brotli 8.0.4",
+ "brotli",
  "flate2",
  "foreign-types",
  "libc",
@@ -275,34 +272,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 4.0.3",
-]
-
-[[package]]
-name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 5.0.3",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -321,10 +297,10 @@ version = "0.1.2"
 dependencies = [
  "adblock",
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "boring-sys2",
  "boring2",
- "brotli 7.0.0",
+ "brotli",
  "bytes",
  "chrono",
  "criterion",
@@ -349,7 +325,7 @@ dependencies = [
  "png 0.17.16",
  "quinn",
  "rand 0.10.2",
- "rand_chacha 0.10.0",
+ "rand_chacha",
  "rand_distr",
  "rustfft",
  "rustls",
@@ -357,7 +333,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha1 0.11.0",
+ "sha1",
  "sha2",
  "skia-safe",
  "swash",
@@ -368,7 +344,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "url",
- "webpki-root-certs 0.26.11",
+ "webpki-root-certs",
  "webpki-roots 1.0.9",
  "zstd",
 ]
@@ -495,7 +471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -633,15 +609,6 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -729,16 +696,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -770,7 +727,7 @@ checksum = "8ed0bfc2096207522de1b7826b0fdd85587e19d0d61368411ad3f193166376b2"
 dependencies = [
  "anyhow",
  "az",
- "base64",
+ "base64 0.22.1",
  "bincode",
  "bit-set",
  "bit-vec",
@@ -873,23 +830,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1201,16 +1148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,18 +1162,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1244,7 +1169,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -1257,9 +1182,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glow"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+checksum = "263218b0ba2b0715c3370fb04674f5f8aa331594b521c94ff0a8e4a8472d1386"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2265,12 +2190,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2292,16 +2211,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -2309,16 +2218,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2336,15 +2235,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "rand_core"
@@ -2572,7 +2462,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.9",
+ "webpki-root-certs",
  "windows-sys 0.61.2",
 ]
 
@@ -2764,24 +2654,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2791,8 +2670,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2847,9 +2726,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a38f4d460276ea40588c958396a9de0eec808c679009a5b52afdf6ebf34132"
+checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2864,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
+checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
 dependencies = [
  "bitflags 2.13.1",
  "skia-bindings",
@@ -3092,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfde4e2f8595f222ceaae1fb16b4963952e9b33e358869dc4cd6316b0e0790cd"
+checksum = "340a09581f29809fc0df82a3955501dc7f2a21f887e5d1c13dbe288fe1c0bef4"
 dependencies = [
  "arrayvec",
  "grid",
@@ -3301,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.27.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -3421,21 +3300,20 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.27.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.7",
+ "sha1",
  "thiserror 2.0.19",
- "utf-8",
 ]
 
 [[package]]
@@ -3506,12 +3384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,15 +3443,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3666,15 +3529,6 @@ dependencies = [
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.9",
 ]
 
 [[package]]
@@ -3908,12 +3762,6 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "adblock",
  "async-trait",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide_mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "browser_oxide",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.408.0"
+version = "0.404.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d2bf3bf9a7dd3f4184cf3af56ce9f06b7bb9cab93497ec3acd04196c9db3f"
+checksum = "8ed0bfc2096207522de1b7826b0fdd85587e19d0d61368411ad3f193166376b2"
 dependencies = [
  "anyhow",
  "az",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.284.0"
+version = "0.280.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a12781597d3e7e407a83b9f11790d59fbcccb8cb32859f121b3b90291e1a026"
+checksum = "7404a038088a57bb9d73e48975a0359d869e69edc450f4a30fe5416652b4b470"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -2737,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.317.0"
+version = "0.313.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f840e3a70bc8b320b014d4a6959c5d177c2a12e7aa561260843bd865cc86436"
+checksum = "3b033e7b24fef6a1c2b47c7a435568504955392440b3562a89dbd4b6a390c27a"
 dependencies = [
  "deno_error",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "adblock"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6fe7702c798519299bcbe011ff6f1dc9e3aedc1f3171178cddf71e1736bf95"
+checksum = "77420e48225975c472eaea1b7c767af6caebea02d910043b0af7a1271d47ec9c"
 dependencies = [
  "addr",
  "arrayvec",
@@ -14,12 +14,12 @@ dependencies = [
  "bitflags 2.11.1",
  "flatbuffers",
  "idna",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "memchr",
  "percent-encoding",
  "precomputed-hash",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "seahash",
  "serde",
  "serde_json",
@@ -169,7 +169,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.404.0"
+version = "0.408.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed0bfc2096207522de1b7826b0fdd85587e19d0d61368411ad3f193166376b2"
+checksum = "9c1d2bf3bf9a7dd3f4184cf3af56ce9f06b7bb9cab93497ec3acd04196c9db3f"
 dependencies = [
  "anyhow",
  "az",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.280.0"
+version = "0.284.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404a038088a57bb9d73e48975a0359d869e69edc450f4a30fe5416652b4b470"
+checksum = "2a12781597d3e7e407a83b9f11790d59fbcccb8cb32859f121b3b90291e1a026"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -1676,6 +1676,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,7 +2226,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2238,7 +2247,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2462,12 +2471,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2742,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.313.0"
+version = "0.317.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b033e7b24fef6a1c2b47c7a435568504955392440b3562a89dbd4b6a390c27a"
+checksum = "4f840e3a70bc8b320b014d4a6959c5d177c2a12e7aa561260843bd865cc86436"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -2907,7 +2910,7 @@ dependencies = [
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
  "unicode-id-start",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "adblock",
  "async-trait",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide_mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "browser_oxide",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.17.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b01d27060ad58be4663b9e4ac9e2d4806918e8876af8912afbddd1a91d5eaa"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "gzip-header"
@@ -3064,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.8.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaef0ac998e6527d6d0d5582f7e43953bb17221ac75bb8eb2fcc2db3396db1c"
+checksum = "dfde4e2f8595f222ceaae1fb16b4963952e9b33e358869dc4cd6316b0e0790cd"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "addr",
  "arrayvec",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "flatbuffers",
  "idna",
  "itertools 0.14.0",
@@ -60,9 +60,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -90,25 +90,25 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -119,9 +119,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "az"
@@ -160,7 +160,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -170,8 +170,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn",
+ "shlex 1.3.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -197,18 +197,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -253,9 +253,9 @@ version = "4.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "boring-sys2",
- "brotli 8.0.2",
+ "brotli 8.0.4",
  "flate2",
  "foreign-types",
  "libc",
@@ -270,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17d4f95e880cfd28c4ca5a006cf7f6af52b4bcb7b5866f573b2faa126fb7affb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -286,13 +286,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 5.0.0",
+ "brotli-decompressor 5.0.3",
 ]
 
 [[package]]
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -348,7 +348,7 @@ dependencies = [
  "percent-encoding",
  "png 0.17.16",
  "quinn",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_chacha 0.10.0",
  "rand_distr",
  "rustfft",
@@ -362,14 +362,14 @@ dependencies = [
  "skia-safe",
  "swash",
  "taffy",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-boring2",
  "tokio-tungstenite",
  "tracing",
  "url",
  "webpki-root-certs 0.26.11",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "zstd",
 ]
 
@@ -383,28 +383,28 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -415,9 +415,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "calendrical_calculations"
@@ -446,7 +446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b4a6cae9efc04cc6cbb8faf338d2c497c165c83e74509cf4dbedea948bbf6e5"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -457,21 +457,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -490,15 +484,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -558,18 +552,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -704,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -714,18 +708,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -803,7 +797,7 @@ dependencies = [
  "sourcemap",
  "static_assertions",
  "sys_traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "url",
  "v8",
@@ -833,7 +827,7 @@ checksum = "1c28ede88783f14cd8aae46ca89f230c226b40e4a81ab06fa52ed72af84beb2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -848,9 +842,9 @@ dependencies = [
  "stringcase",
  "strum",
  "strum_macros",
- "syn",
+ "syn 2.0.119",
  "syn-match",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -862,7 +856,7 @@ dependencies = [
  "deno_error",
  "percent-encoding",
  "sys_traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
 ]
 
@@ -907,7 +901,7 @@ dependencies = [
  "diplomat_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -927,25 +921,25 @@ dependencies = [
  "serde",
  "smallvec",
  "strck",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -965,21 +959,21 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash",
  "libm",
- "rand 0.9.4",
+ "portable-atomic",
  "siphasher",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -1012,7 +1006,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "rustc_version",
 ]
 
@@ -1035,15 +1029,15 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.11.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
 dependencies = [
  "bytemuck",
 ]
@@ -1072,13 +1066,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1120,9 +1114,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1135,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1145,15 +1139,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1162,38 +1156,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1236,32 +1230,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glow"
@@ -1327,15 +1319,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -1578,12 +1561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,7 +1609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -1698,27 +1675,32 @@ checksum = "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.19",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1737,28 +1719,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1769,16 +1750,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1825,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1848,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -1870,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1907,13 +1882,13 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1964,7 +1939,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2070,7 +2045,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2132,12 +2107,18 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -2172,7 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2186,18 +2167,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "psl"
-version = "2.1.210"
+version = "2.1.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fbd4d9b2eb0b6e0cbd654bce70243f460cbc8dc92df6747e3fb911ce1cd4a8"
+checksum = "c0dedad316e05de220cbf3fd8bfb69f3df8755dde2d7d479211827b595168a93"
 dependencies = [
  "psl-types",
 ]
@@ -2210,15 +2191,15 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2229,7 +2210,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -2237,22 +2218,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2260,23 +2242,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2301,18 +2283,18 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2320,12 +2302,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2377,7 +2359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2402,12 +2393,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
  "font-types",
+ "once_cell",
 ]
 
 [[package]]
@@ -2416,14 +2408,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2433,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2444,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "resb"
@@ -2474,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2507,7 +2499,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2520,7 +2512,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2529,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "once_cell",
  "ring",
@@ -2543,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2555,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2565,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2580,7 +2572,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.9",
  "windows-sys 0.61.2",
 ]
 
@@ -2603,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustybuzz"
@@ -2613,7 +2605,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytemuck",
  "core_maths",
  "log",
@@ -2667,7 +2659,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2692,9 +2684,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2702,29 +2694,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2753,7 +2745,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "v8",
 ]
 
@@ -2772,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2810,6 +2802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,9 +2819,25 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -2833,9 +2847,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.97.0"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e3bcf8f25bf047e83110838463e8d06696c12fccc3d3794adf448b4d81f34b"
+checksum = "e6a38f4d460276ea40588c958396a9de0eec808c679009a5b52afdf6ebf34132"
 dependencies = [
  "bindgen",
  "cc",
@@ -2850,19 +2864,19 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.97.0"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935d4d174fb749bac9265eb41cad75039d32fda2d9c1a1e81b430df0e210a409"
+checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "skia-bindings",
 ]
 
 [[package]]
 name = "skrifa"
-version = "0.40.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -2885,15 +2899,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2992,7 +3006,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3003,9 +3017,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swash"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
+checksum = "6c2499c2d826531388872b2268718aed907a39bd785ab0dcfe57fab26283f92e"
 dependencies = [
  "skrifa",
  "yazi",
@@ -3014,9 +3028,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3031,7 +3056,7 @@ checksum = "54b8f0a9004d6aafa6a588602a1119e6cdaacec9921aa1605383e6e7d6258fd6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3042,7 +3067,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3062,7 +3087,7 @@ checksum = "181f22127402abcf8ee5c83ccd5b408933fec36a6095cf82cda545634692657e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3096,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "temporal_capi"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a1f001e756a9f5f2d175a9965c4c0b3a054f09f30de3a75ab49765f2deb36"
+checksum = "c534c1ac4165fb410b5ccd12c79040573622865e881bb8caad70981806a141f1"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -3113,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "temporal_rs"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a902a45282e5175186b21d355efc92564601efe6e2d92818dc9e333d50bd4de"
+checksum = "b1afc06e45b0d63943c777d0233523fa2e23a12431a73c37b1c0366777b31717"
 dependencies = [
  "calendrical_calculations",
  "core_maths",
@@ -3130,12 +3155,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -3149,11 +3173,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -3164,25 +3188,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "timezone_provider"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f9b04628a2b813051e4dfe97c65281e49625eabd09ec343190e31e399a8c2"
+checksum = "48738555f588bc05b58cb55206843cde9875bb1fde50101dd1a7c50ac6535cd5"
 dependencies = [
  "tinystr",
  "zerotrie",
@@ -3213,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3228,9 +3252,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3256,13 +3280,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3293,22 +3317,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3330,18 +3355,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -3363,7 +3388,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3405,19 +3430,19 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror 2.0.18",
+ "sha1 0.10.7",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-bidi-mirroring"
@@ -3454,12 +3479,6 @@ name = "unicode-script"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3500,9 +3519,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3515,7 +3534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebfd8d6919bfb4b627ca778a67f85ca45e5fb442d352947ba093798bdf9b07e0"
 dependencies = [
  "bindgen",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "fslock",
  "gzip-header",
  "home",
@@ -3555,27 +3574,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3586,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3596,46 +3606,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -3645,26 +3633,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a10e6b67c951a84de7029487e0e0a496860dae49f6699edd279d5ff35b8fbf54"
 dependencies = [
  "deno_error",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3682,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -3698,14 +3674,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.9",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3716,14 +3692,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3792,7 +3768,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3803,7 +3779,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3832,20 +3808,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3854,16 +3821,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3877,57 +3835,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3936,34 +3856,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3972,28 +3868,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4002,34 +3880,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4038,34 +3892,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winsafe"
@@ -4075,97 +3911,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -4200,9 +3948,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4217,7 +3965,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4229,22 +3977,22 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4264,15 +4012,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -4306,20 +4054,20 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zoneinfo64"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.403.0"
+version = "0.404.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3c1fcdf9cccb942bfd3f24cb0118c899837434d5b887a374bab7ce45ace6da"
+checksum = "8ed0bfc2096207522de1b7826b0fdd85587e19d0d61368411ad3f193166376b2"
 dependencies = [
  "anyhow",
  "az",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.279.0"
+version = "0.280.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59263ebf5578416f8195220aca525c89b29c6616d8171bdfc4df3d3bf4d8da58"
+checksum = "7404a038088a57bb9d73e48975a0359d869e69edc450f4a30fe5416652b4b470"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -2742,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.312.0"
+version = "0.313.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d8ed4ae5203d63dfcc13c8eed95343d18c732940823ad4fb2fbd57a8141688"
+checksum = "3b033e7b24fef6a1c2b47c7a435568504955392440b3562a89dbd4b6a390c27a"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -3507,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "149.2.0"
+version = "149.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dccf61a364b61bbaac70a8ba64a1a1006e87123b7d62eaeec999a3ba31ecdb"
+checksum = "ebfd8d6919bfb4b627ca778a67f85ca45e5fb442d352947ba093798bdf9b07e0"
 dependencies = [
  "bindgen",
  "bitflags 2.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "boring-sys2"
 version = "4.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,7 +357,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha1",
+ "sha1 0.11.0",
  "sha2",
  "skia-safe",
  "swash",
@@ -592,6 +601,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,8 +883,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1380,6 +1415,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -2731,18 +2775,29 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3350,7 +3405,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/browser_oxide", "crates/browser_oxide_mcp"]
 exclude = ["crates/browser_oxide_py"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Yury Fedoseev"]
@@ -39,7 +39,7 @@ doc_overindented_list_items = "allow"
 # The single engine crate — depended on by browser_oxide_mcp. Explicit
 # version pinned to the workspace version so cargo-deny's `wildcards =
 # "deny"` rule doesn't trip on path-only `version = "*"` resolution.
-browser_oxide = { version = "0.1.1", path = "crates/browser_oxide" }
+browser_oxide = { version = "0.1.2", path = "crates/browser_oxide" }
 
 # Async runtime + common derive deps shared by multiple crates.
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/browser_oxide", "crates/browser_oxide_mcp"]
 exclude = ["crates/browser_oxide_py"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Yury Fedoseev"]
@@ -39,7 +39,7 @@ doc_overindented_list_items = "allow"
 # The single engine crate — depended on by browser_oxide_mcp. Explicit
 # version pinned to the workspace version so cargo-deny's `wildcards =
 # "deny"` rule doesn't trip on path-only `version = "*"` resolution.
-browser_oxide = { version = "0.1.0", path = "crates/browser_oxide" }
+browser_oxide = { version = "0.1.1", path = "crates/browser_oxide" }
 
 # Async runtime + common derive deps shared by multiple crates.
 tokio = { version = "1", features = ["full"] }

--- a/crates/browser_oxide/Cargo.toml
+++ b/crates/browser_oxide/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["full"] }
 futures-util = "0.3"
 async-trait = "0.1"
 # --- V8 / JS ---
-deno_core = "0.403"
+deno_core = "0.404"
 deno_error = "0.7"
 # --- serialization ---
 serde = { version = "1", features = ["derive"] }

--- a/crates/browser_oxide/Cargo.toml
+++ b/crates/browser_oxide/Cargo.toml
@@ -92,7 +92,7 @@ swash = "0.2"
 rustfft = "6"
 glow = { version = "0.17", optional = true }
 # --- layout ---
-taffy = "0.8"
+taffy = "0.11"
 # --- misc ---
 chrono = "0.4"
 thiserror = "2"

--- a/crates/browser_oxide/Cargo.toml
+++ b/crates/browser_oxide/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "browser_oxide"
 version.workspace = true
 edition.workspace = true
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["full"] }
 futures-util = "0.3"
 async-trait = "0.1"
 # --- V8 / JS ---
-deno_core = "0.408"
+deno_core = "0.404"
 deno_error = "0.7"
 # --- serialization ---
 serde = { version = "1", features = ["derive"] }

--- a/crates/browser_oxide/Cargo.toml
+++ b/crates/browser_oxide/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+﻿[package]
 name = "browser_oxide"
 version.workspace = true
 edition.workspace = true
@@ -7,7 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "Stealth headless browser engine in Rust: real HTML/CSS/DOM/JS, V8 via deno_core, own BoringSSL TLS/JA4 fingerprint, no Chromium, no CDP — for anti-bot web scraping, archival, and AI agents"
+description = "Stealth headless browser engine in Rust: real HTML/CSS/DOM/JS, V8 via deno_core, own BoringSSL TLS/JA4 fingerprint, no Chromium, no CDP â€” for anti-bot web scraping, archival, and AI agents"
 keywords = [
   "stealth-browser",
   "headless-browser",
@@ -74,8 +74,8 @@ flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
 brotli = "7"
 zstd = "0.13"
 # --- crypto / hashing / rng ---
-sha1 = "0.10"
-sha2 = "0.10"
+sha1 = "0.11"
+sha2 = "0.11"
 rand = "0.10"
 rand_chacha = "0.10"
 rand_distr = "0.6"
@@ -104,7 +104,7 @@ tracing = "0.1"
 tokio = { version = "1", features = ["full", "test-util"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 tokio-tungstenite = "0.27"
 futures-util = "0.3"

--- a/crates/browser_oxide/Cargo.toml
+++ b/crates/browser_oxide/Cargo.toml
@@ -52,13 +52,13 @@ boring2 = { version = "4.15", features = [
 ] }
 boring-sys2 = "4.15"
 tokio-boring2 = "4.15"
-webpki-root-certs = "0.26"
+webpki-root-certs = "1.0"
 webpki-roots = "1"
 http = "1"
 http2 = { version = "0.5", features = ["unstable"] }
 bytes = "1"
 foreign-types = "0.5"
-tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
 quinn = "0.11"
 h3 = "0.0.8"
 h3-quinn = "0.0.10"
@@ -71,7 +71,7 @@ adblock = { version = "0.13", optional = true }
 # zlib-rs backend: canvas pins exact PNG output bytes (png_byte_parity test),
 # which the miniz_oxide default backend does not reproduce.
 flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
-brotli = "7"
+brotli = "8"
 zstd = "0.13"
 # --- crypto / hashing / rng ---
 sha1 = "0.11"
@@ -80,7 +80,7 @@ rand = "0.10"
 rand_chacha = "0.10"
 rand_distr = "0.6"
 # --- canvas / graphics / fonts ---
-skia-safe = "0.97"
+skia-safe = "0.99"
 png = "0.17"
 image = { version = "0.25", default-features = false, features = [
   "png",
@@ -90,13 +90,13 @@ fontdb = { version = "0.23", default-features = false }
 rustybuzz = "0.20"
 swash = "0.2"
 rustfft = "6"
-glow = { version = "0.17", optional = true }
+glow = { version = "0.18", optional = true }
 # --- layout ---
-taffy = "0.11"
+taffy = "0.12"
 # --- misc ---
 chrono = "0.4"
 thiserror = "2"
-base64 = "0.22"
+base64 = "0.23"
 lazy_static = "1"
 tracing = "0.1"
 
@@ -106,7 +106,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
 hex = "0.4"
-tokio-tungstenite = "0.27"
+tokio-tungstenite = "0.30"
 futures-util = "0.3"
 url = "2"
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/crates/browser_oxide/Cargo.toml
+++ b/crates/browser_oxide/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["full"] }
 futures-util = "0.3"
 async-trait = "0.1"
 # --- V8 / JS ---
-deno_core = "0.404"
+deno_core = "0.408"
 deno_error = "0.7"
 # --- serialization ---
 serde = { version = "1", features = ["derive"] }
@@ -66,7 +66,7 @@ rustls = { version = "0.23", default-features = false, features = [
   "ring",
   "std",
 ] }
-adblock = { version = "0.12", optional = true }
+adblock = { version = "0.13", optional = true }
 # --- compression ---
 # zlib-rs backend: canvas pins exact PNG output bytes (png_byte_parity test),
 # which the miniz_oxide default backend does not reproduce.

--- a/crates/browser_oxide/examples/canvas_fp_probe.rs
+++ b/crates/browser_oxide/examples/canvas_fp_probe.rs
@@ -1,0 +1,49 @@
+//! Prints the canvas fingerprint data-URL length + digest for a fixed profile.
+//!
+//! Used to prove that a `png` crate bump does not perturb the encoded IDAT
+//! bytes: run it on two checkouts and compare. The canvas fingerprint is a
+//! stealth-critical output, so the PNG encoder must stay byte-stable across
+//! dependency upgrades.
+
+use browser_oxide::Page;
+
+const CANVAS_FP_SEQUENCE_JS: &str = r#"(() => {
+    const c = document.createElement('canvas');
+    c.width = 200; c.height = 60;
+    const ctx = c.getContext('2d');
+    if (!ctx) return 'NO_CTX';
+    ctx.textBaseline = 'top';
+    ctx.font = '14px Arial';
+    ctx.fillStyle = '#f60';
+    ctx.fillRect(0, 0, 100, 30);
+    ctx.fillStyle = '#069';
+    ctx.fillText('browser_oxide', 2, 15);
+    ctx.fillStyle = 'rgba(102, 204, 0, 0.7)';
+    ctx.fillText('parity-test', 4, 17);
+    ctx.beginPath();
+    ctx.arc(150, 30, 12, 0, Math.PI * 2);
+    ctx.fill();
+    return c.toDataURL();
+})()"#;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let profile = browser_oxide::stealth::chrome_148_macos();
+    let mut page = Page::from_html(
+        "<!DOCTYPE html><html><head></head><body></body></html>",
+        Some(profile),
+    )
+    .await
+    .expect("page");
+
+    let data_url = page.evaluate(CANVAS_FP_SEQUENCE_JS).expect("eval");
+
+    // Simple FNV-1a so this example carries no extra dependency and behaves
+    // identically on both checkouts regardless of their sha2 version.
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in data_url.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    println!("len={} fnv1a={:016x}", data_url.len(), h);
+}

--- a/crates/browser_oxide/src/canvas/canvas2d.rs
+++ b/crates/browser_oxide/src/canvas/canvas2d.rs
@@ -1171,6 +1171,16 @@ impl Canvas2D {
             let mut encoder = png::Encoder::new(&mut buf, self.width, self.height);
             encoder.set_color(png::ColorType::Rgba);
             encoder.set_depth(png::BitDepth::Eight);
+            // DO NOT bump the `png` crate without re-validating canvas
+            // fingerprint output. png 0.18 merges `FilterType` +
+            // `AdaptiveFilterType` into a single `Filter` enum, and although
+            // `Compression::Balanced` does map back to the same flate2 level
+            // this uses, `Filter::Adaptive` is NOT equivalent to the
+            // `Paeth` + adaptive pair below: measured on the standard
+            // FingerprintJS canvas sequence, 0.18 emits a 9,646-byte data URL
+            // where 0.17 emits 17,502. That is a different fingerprint for
+            // every canvas the engine renders. See
+            // `examples/canvas_fp_probe.rs` for the A/B harness.
             encoder.set_compression(png::Compression::Default);
             encoder.set_filter(png::FilterType::Paeth);
             encoder.set_adaptive_filter(png::AdaptiveFilterType::Adaptive);

--- a/crates/browser_oxide/src/js_runtime/js/cleanup_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/cleanup_bootstrap.js
@@ -633,6 +633,123 @@
         internals.push('SharedArrayBuffer');
     }
 
+    // -- Warm-reuse global-namespace reset ---------------------------
+    // The last retention source for a pooled `Page`: properties page
+    // scripts hang straight off the global (`window.__APP_STATE = …`,
+    // `window.onscroll = …`, framework singletons). `globalThis` is the
+    // same object for the whole life of the `JsRuntime`, so on the warm
+    // path every one of those — and everything they transitively
+    // reference — survives into the next navigation. A real browser gives
+    // each navigation a fresh global; this is the closest equivalent that
+    // keeps the expensive bootstrap intact.
+    //
+    // `__markGlobalsBaseline()` snapshots the engine-owned key set;
+    // `__resetPageGlobals()` deletes everything added since. Rust re-marks
+    // the baseline once more after it installs the post-bootstrap
+    // instrumentation (`__cookieWrites` / `__scriptErrors` / the fetch +
+    // XHR wrappers), which is why those names are also allowlisted below —
+    // construction paths that skip the re-mark must not lose them.
+    // Note `window === globalThis` here (dom_bootstrap.js), so scrubbing
+    // the global object covers both.
+    // Guarded: this file is executed TWICE per page — once from
+    // `BrowserJsRuntime`'s constructor (before any page script) and again
+    // from `build_page_with_scripts_*` after the document's scripts have
+    // run. Only the first execution may seed the baseline; re-running the
+    // definitions would also reset the closure variable and throw the real
+    // baseline away.
+    if (typeof globalThis.__resetPageGlobals !== 'function') {
+        let _globalsBaseline = null;
+        let _onHandlerBaseline = null;
+        const _BASELINE_ALWAYS = [
+            '_browser_oxide', '__cookieWrites', '__scriptErrors',
+            '__bo_input_events', '__jsCookies',
+        ];
+
+        // `on*` handlers need value-level treatment, not just key-level.
+        // `onscroll`, `onerror`, … already EXIST as own properties of the
+        // global at bootstrap (default `null`), so a page that assigns
+        // `window.onscroll = fn` mutates a baseline key rather than adding
+        // one — the key-set diff below cannot see it, and the closure (plus
+        // everything it captures) survives the navigation.
+        //
+        // Blanket-nulling them is wrong: the engine itself installs
+        // `window.onerror` as its script-error instrumentation, once, and
+        // does NOT re-install it on the warm path. So snapshot the values
+        // at baseline and RESTORE them, which nulls page assignments while
+        // preserving the engine's.
+        const _snapshotOnHandlers = (target) => {
+            const m = new Map();
+            if (!target) return m;
+            let names;
+            try { names = Object.getOwnPropertyNames(target); } catch (_e) { return m; }
+            for (const k of names) {
+                if (!k.startsWith('on')) continue;
+                try { m.set(k, target[k]); } catch (_e) {}
+            }
+            return m;
+        };
+        const _restoreOnHandlers = (target, baseline) => {
+            if (!target || !baseline) return;
+            let names;
+            try { names = Object.getOwnPropertyNames(target); } catch (_e) { return; }
+            for (const k of names) {
+                if (!k.startsWith('on')) continue;
+                try {
+                    if (typeof target[k] !== 'function') continue;
+                    const orig = baseline.get(k);
+                    // Already the engine's own handler ⇒ leave it alone.
+                    if (orig === target[k]) continue;
+                    target[k] = (typeof orig === 'function') ? orig : null;
+                } catch (_e) {}
+            }
+        };
+
+        Object.defineProperty(globalThis, '__markGlobalsBaseline', {
+            value: function __markGlobalsBaseline() {
+                const seen = new Set(_BASELINE_ALWAYS);
+                for (const k of Object.getOwnPropertyNames(globalThis)) seen.add(k);
+                for (const s of Object.getOwnPropertySymbols(globalThis)) seen.add(s);
+                _globalsBaseline = seen;
+                // `document` is a singleton that survives `replace_dom`, so
+                // `document.onclick = fn` persists exactly like the window
+                // case and needs the same treatment.
+                _onHandlerBaseline = {
+                    global: _snapshotOnHandlers(globalThis),
+                    document: _snapshotOnHandlers(globalThis.document),
+                };
+            },
+            writable: true, configurable: true, enumerable: false,
+        });
+        Object.defineProperty(globalThis, '__resetPageGlobals', {
+            value: function __resetPageGlobals() {
+                // No baseline ⇒ nothing to compare against; deleting on a
+                // guess would strip the engine's own globals.
+                if (!_globalsBaseline) return 0;
+                let removed = 0;
+                const keys = Object.getOwnPropertyNames(globalThis)
+                    .concat(Object.getOwnPropertySymbols(globalThis));
+                for (const k of keys) {
+                    if (_globalsBaseline.has(k)) continue;
+                    // Best-effort: a page can install a non-configurable
+                    // property, and `delete` cannot remove those.
+                    try { if (delete globalThis[k]) removed++; } catch (_e) {}
+                }
+                if (_onHandlerBaseline) {
+                    _restoreOnHandlers(globalThis, _onHandlerBaseline.global);
+                    _restoreOnHandlers(globalThis.document, _onHandlerBaseline.document);
+                }
+                return removed;
+            },
+            writable: true, configurable: true, enumerable: false,
+        });
+        // Seed the baseline on this first execution: it runs as the last
+        // bootstrap, before anything page-authored, so the global namespace
+        // is exactly the engine's. Rust re-marks once more after installing
+        // the post-bootstrap instrumentation. The `internals` purge below
+        // only ever REMOVES keys, so marking before it is safe.
+        globalThis.__markGlobalsBaseline();
+    }
+
     for (const name of internals) {
         [globalThis, globalThis.window].forEach(obj => {
             if (!obj || !(name in obj)) return;
@@ -648,4 +765,5 @@
             }
         });
     }
+
 })(globalThis);

--- a/crates/browser_oxide/src/js_runtime/js/dom_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/dom_bootstrap.js
@@ -3349,4 +3349,40 @@
         configurable: true,
         writable: false,
     });
+
+    // Warm-reuse DOM-registry reaper. Every registry below is module-private
+    // and keyed by (or holding) state that belongs to ONE document, yet it
+    // lives as long as the `JsRuntime`. On the cold path that is exactly the
+    // life of the page, so nothing was ever pruned; on the warm path
+    // (`PagePool` / `Page::navigate_warm`) `replace_dom` swaps the document
+    // underneath them and they accumulate forever. See
+    // `Page::reset_for_reuse`, which calls this.
+    //
+    // `_nodeCache` is doubly wrong across a swap: it is keyed by `nodeId`, and
+    // node IDs restart at zero for the new document, so a surviving entry
+    // hands the NEW page's node the OLD page's wrapper (with the old page's
+    // expandos on it). The `WeakRef` values do not save us — an old wrapper
+    // stays alive as long as any listener closure references it.
+    Object.defineProperty(globalThis, '__resetDomRegistries', {
+        value: function __resetDomRegistries() {
+            _nodeCache.clear();
+            _scrollState.clear();
+            _syncFetchInFlight.clear();
+            // Observers registered by the previous page's scripts. Pages
+            // routinely never call `disconnect()`, so this only shrinks on
+            // reuse — each retained observer pins its callback closure and
+            // every observed target wrapper.
+            _moObservers.length = 0;
+            _appendedIframes.length = 0;
+            _frameRegistry.length = 0;
+            try { globalThis.__ifAppendCount = 0; } catch (_) {}
+            // Re-seed the document wrapper: `_wrapNode` must keep returning
+            // the singleton `_document` for the document node id, which
+            // `replace_dom` preserves.
+            try { _nodeCache.set(ops.op_dom_document_node(), new WeakRef(_document)); } catch (_) {}
+        },
+        writable: true,
+        configurable: true,
+        enumerable: false,
+    });
 })(globalThis);

--- a/crates/browser_oxide/src/js_runtime/js/event_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/event_bootstrap.js
@@ -1,5 +1,4 @@
 ((globalThis) => {
-    const _listeners = new Map(); // nodeId → Map<eventType, [{callback, capture, once}]>
     // ---- Trusted-event authenticity (v0.1.0 behavioral E1) ----------------
     // `isTrusted` MUST be both unforgeable and shaped like a real browser's:
     //   * a GETTER on Event.prototype — NOT an own data property. Scripts
@@ -295,7 +294,40 @@
 
     // --- EventTarget core logic ---
     const _nodeListeners = new Map(); // nodeId → Map<eventType, [{callback, capture, once}]>
-    const _objListeners = new WeakMap(); // object → Map<eventType, [{callback, capture, once}]>
+    let _objListeners = new WeakMap(); // object → Map<eventType, [{callback, capture, once}]>
+
+    // Warm-reuse listener reaper — the events-side analogue of
+    // `timer_bootstrap.js`'s `__cancelAllTimers()`. A pooled `Page`
+    // (`PagePool` / `Page::navigate_warm`) keeps ONE `JsRuntime` alive across
+    // navigations, so both registries above outlive the document they were
+    // populated for. Two distinct failures follow:
+    //
+    //   * Leak. `_objListeners` is keyed by target *object*; listeners a page
+    //     attaches to `window`/`globalThis` (analytics, scroll handlers, …)
+    //     are keyed against the one global that is never collected for the
+    //     life of the isolate, so those callbacks — and every closure
+    //     variable they capture, which can be the page's whole object graph —
+    //     are retained forever. `_nodeListeners` is worse: it is a *strong*
+    //     Map that is never pruned at all. Measured at ~10 MB/page of live
+    //     (non-GC-able) V8 heap on real product pages, unbounded.
+    //   * Cross-page misfire. `_nodeListeners` is keyed by `nodeId`, and node
+    //     IDs restart from zero when `replace_dom` swaps the document. The
+    //     previous page's handler for node 42 therefore fires on the *new*
+    //     page's node 42.
+    //
+    // Called from `Page::reset_for_reuse` alongside `__cancelAllTimers()`.
+    // Non-enumerable so it does not widen `Object.getOwnPropertyNames(window)`.
+    Object.defineProperty(globalThis, '__cancelAllListeners', {
+        value: function __cancelAllListeners() {
+            _nodeListeners.clear();
+            // Reassign rather than clear: WeakMap has no `clear()`, and the
+            // whole point is to drop the `window`-keyed entry.
+            _objListeners = new WeakMap();
+        },
+        writable: true,
+        configurable: true,
+        enumerable: false,
+    });
 
     const _getNodeIdOrMinusOne = (globalThis.__browser_oxide && globalThis.__browser_oxide._getNodeId)
         ? globalThis.__browser_oxide._getNodeId

--- a/crates/browser_oxide/src/js_runtime/js/window_bootstrap.js
+++ b/crates/browser_oxide/src/js_runtime/js/window_bootstrap.js
@@ -7081,4 +7081,21 @@
     for (let i = 0; i < 5; i++) _defineIframeGetter(i);
 
     Object.defineProperty(globalThis, Symbol.toStringTag, { value: "Window", configurable: true });
+
+    // Warm-reuse custom-element reaper. Both registries hold page-supplied
+    // constructors (and, for `whenDefined`, unresolved promise resolvers)
+    // for the life of the `JsRuntime`, so on a pooled `Page` they retain
+    // every class every previously-loaded document ever defined. Clearing
+    // also fixes a correctness bug: re-`define()`ing a name the *previous*
+    // page had already registered is a no-op today, so the new page's
+    // element class never upgrades. Called by `Page::reset_for_reuse`.
+    Object.defineProperty(globalThis, '__resetCustomElements', {
+        value: function __resetCustomElements() {
+            _customElementsRegistry.clear();
+            _whenDefinedPromises.clear();
+        },
+        writable: true,
+        configurable: true,
+        enumerable: false,
+    });
 })(globalThis);

--- a/crates/browser_oxide/src/js_runtime/mod.rs
+++ b/crates/browser_oxide/src/js_runtime/mod.rs
@@ -140,7 +140,10 @@ impl BrowserJsRuntime {
     /// Note this is V8 heap only — it excludes external/`ArrayBuffer` backing
     /// stores and everything Rust-side, so it is not process RSS.
     pub fn v8_heap_used_bytes(&mut self) -> usize {
-        self.inner.v8_isolate().get_heap_statistics().used_heap_size()
+        self.inner
+            .v8_isolate()
+            .get_heap_statistics()
+            .used_heap_size()
     }
 
     /// Ask V8 to perform a full garbage collection.

--- a/crates/browser_oxide/src/js_runtime/mod.rs
+++ b/crates/browser_oxide/src/js_runtime/mod.rs
@@ -130,6 +130,31 @@ impl BrowserJsRuntime {
         self.inner.v8_isolate().cancel_terminate_execution();
     }
 
+    /// V8's `used_heap_size` for this isolate, in bytes.
+    ///
+    /// Intended for monitoring warm reuse: pair with [`Self::collect_garbage`]
+    /// and sample after each navigation. On a healthy pool the value is flat
+    /// across navigations; a monotonic climb means something is retaining the
+    /// previous page (see `Page::reset_for_reuse`).
+    ///
+    /// Note this is V8 heap only — it excludes external/`ArrayBuffer` backing
+    /// stores and everything Rust-side, so it is not process RSS.
+    pub fn v8_heap_used_bytes(&mut self) -> usize {
+        self.inner.v8_isolate().get_heap_statistics().used_heap_size()
+    }
+
+    /// Ask V8 to perform a full garbage collection.
+    ///
+    /// Only meaningful for measurement: call it before
+    /// [`Self::v8_heap_used_bytes`] so the reading reflects *live* (reachable)
+    /// objects rather than not-yet-collected garbage. Without it, heap-growth
+    /// numbers are dominated by GC scheduling noise. Not a correctness tool —
+    /// never call it on a hot path.
+    pub fn collect_garbage(&mut self) {
+        let _guard = IsolateEnterGuard::enter(self.inner.v8_isolate());
+        self.inner.v8_isolate().low_memory_notification();
+    }
+
     /// Execute a JavaScript script and return the string representation of the result.
     ///
     /// Uses V8 directly in a single HandleScope — avoids the overhead of

--- a/crates/browser_oxide/src/net/blocker.rs
+++ b/crates/browser_oxide/src/net/blocker.rs
@@ -124,8 +124,8 @@ mod engine {
             format: FilterFormat::Standard,
             ..Default::default()
         };
-        filter_set.add_filter_list(&rules, parse_opts);
-        Some(Engine::from_filter_set(filter_set, true))
+        filter_set.add_filter_list(rules, parse_opts);
+        Some(Engine::new_with_filter_set(filter_set))
     }
 
     fn with_engine<R>(f: impl FnOnce(Option<&Engine>) -> R) -> R {
@@ -140,11 +140,11 @@ mod engine {
             let Some(eng) = opt_eng else { return false };
             // Falls back to `false` on any parse error — fail-open is safer
             // than fail-closed for an opt-in blocker.
-            let req = match Request::new(url, source_url, request_type) {
+            let req = match Request::new(url, source_url, request_type, "") {
                 Ok(r) => r,
                 Err(_) => return false,
             };
-            eng.check_network_request(&req).matched
+            eng.check_network_request(&req).should_block()
         })
     }
 }

--- a/crates/browser_oxide/src/page.rs
+++ b/crates/browser_oxide/src/page.rs
@@ -982,6 +982,24 @@ impl Page {
         self.event_loop.execute_script(js)
     }
 
+    /// V8's `used_heap_size` for this page's isolate, in bytes.
+    ///
+    /// Useful for monitoring a [`crate::pool::PagePool`]: sample after each
+    /// navigation and the value should stay flat. A monotonic climb means
+    /// something is retaining the previous document — call
+    /// [`Page::reset_for_reuse`] between navigations. Call
+    /// [`Page::collect_garbage`] first if you want live-heap rather than
+    /// including uncollected garbage.
+    pub fn v8_heap_used_bytes(&mut self) -> usize {
+        self.event_loop.runtime_mut().v8_heap_used_bytes()
+    }
+
+    /// Ask V8 for a full garbage collection. Measurement aid only — see
+    /// [`Page::v8_heap_used_bytes`]. Never call this on a hot path.
+    pub fn collect_garbage(&mut self) {
+        self.event_loop.runtime_mut().collect_garbage();
+    }
+
     /// Run scripts and wait for completion.
     pub async fn evaluate_async(
         &mut self,
@@ -1489,15 +1507,38 @@ impl Page {
     }
 
     /// Reset all cross-navigation JS state on this Page so its V8 isolate
-    /// can be safely reused for a different URL. Called by
-    /// [`Page::navigate_warm`] and [`crate::pool::PagePool::navigate`].
+    /// can be safely reused for a different URL.
     ///
-    /// What gets cleared:
+    /// Call this before pointing a warm `Page` at new content.
+    /// [`Page::navigate_warm`] and [`crate::pool::PagePool`] already do;
+    /// any consumer that hand-rolls page reuse (e.g. calling
+    /// [`Page::reload_html`] on a `Page` it keeps alive) must call it
+    /// itself, otherwise the reapers below never run — every one of them
+    /// used to be wired only to `Page::drop`, so a pooling consumer
+    /// silently lost all of them.
+    ///
+    /// What gets reaped:
     /// - In-flight `setTimeout` / `setInterval` callbacks (via
     ///   `__cancelAllTimers()` generation bump in `timer_bootstrap.js`).
     ///   Without this, the previous page's `humanize.js` 30 pending
     ///   timers + recurring 4 s setInterval would fire on the new DOM
     ///   and dispatch synthetic mouse events into the wrong document.
+    /// - Every registered event listener (`__cancelAllListeners()` in
+    ///   `event_bootstrap.js`). Listeners bound to `window` are keyed
+    ///   against the one object that is never collected for the life of
+    ///   the isolate, so their closures pinned the previous page's whole
+    ///   object graph; node-keyed listeners additionally misfired on the
+    ///   next document, because node IDs restart at zero.
+    /// - DOM-side registries (`__resetDomRegistries()` in
+    ///   `dom_bootstrap.js`): node-wrapper cache, scroll state,
+    ///   MutationObservers, iframe/frame registries.
+    /// - Custom-element definitions (`__resetCustomElements()` in
+    ///   `window_bootstrap.js`).
+    /// - Globals the previous page's scripts hung off `window`
+    ///   (`__resetPageGlobals()` in `cleanup_bootstrap.js`) — everything
+    ///   added since the engine marked its baseline.
+    /// - Workers the page spawned but never `terminate()`d
+    ///   (`drain_owned_workers`), which `Page::drop` also does.
     /// - `_browser_oxide.__pendingNavigation` — spurious value left by the
     ///   `location.href = …` setter inside the previous build.
     /// - `_browser_oxide.__fetchLog` — DevTools-style network log; must
@@ -1509,17 +1550,23 @@ impl Page {
     ///   sensors read them on POST, so stale values would skew detection.
     /// - `globalThis.__jsCookies` — cookie cache snapshot (the real
     ///   source of truth is the HTTP client's jar, re-synced below).
+    /// - `globalThis.__keepLongTimersRefed` — per-navigation challenge
+    ///   flag; left set, it would pin long timers on every later page.
     ///
     /// What stays:
     /// - V8 isolate, bootstrap scripts (`window_bootstrap.js`,
     ///   `dom_bootstrap.js`, …), and the page-instrumentation wrappers
     ///   on `globalThis.fetch` / `document.cookie` / `XMLHttpRequest`.
     ///   These are the expensive bits we're reusing.
-    fn reset_warm_state(&mut self) {
+    pub fn reset_for_reuse(&mut self) {
         let _ = self.event_loop.execute_script(
             r#"(function() {
                 const g = globalThis;
                 try { g.__cancelAllTimers && g.__cancelAllTimers(); } catch (_) {}
+                try { g.__cancelAllListeners && g.__cancelAllListeners(); } catch (_) {}
+                try { g.__resetDomRegistries && g.__resetDomRegistries(); } catch (_) {}
+                try { g.__resetCustomElements && g.__resetCustomElements(); } catch (_) {}
+                try { delete g.__keepLongTimersRefed; } catch (_) {}
                 if (g._browser_oxide) {
                     g._browser_oxide.__pendingNavigation = null;
                     if (Array.isArray(g._browser_oxide.__fetchLog)) {
@@ -1543,6 +1590,11 @@ impl Page {
                     }
                 }
                 if (g.__jsCookies) g.__jsCookies = {};
+                // Last: drop everything the previous page's scripts hung
+                // off `window`. Runs after the buffer resets above so those
+                // engine-owned names are already back to a clean value (they
+                // are baseline-allowlisted, so this does not remove them).
+                try { g.__resetPageGlobals && g.__resetPageGlobals(); } catch (_) {}
             })();"#,
         );
         // Reap Workers the OUTGOING page spawned but never terminated. The
@@ -1559,6 +1611,10 @@ impl Page {
             let mut state = op_state.borrow_mut();
             crate::js_runtime::extensions::worker_ext::drain_owned_workers(&mut state);
         }
+        // Drop the previous document's iframe isolates. Children are newer
+        // isolates than this Page's, so clearing here keeps V8's
+        // reverse-creation-order drop requirement satisfied.
+        self.children.clear();
     }
 
     /// Navigate this *warm* Page to a new URL by reusing its V8 isolate
@@ -1800,8 +1856,8 @@ impl Page {
         // Cancel all in-flight timers from the previous page and clear
         // cross-nav JS buffers BEFORE swapping the DOM, so any straggler
         // callbacks that try to fire don't see a half-installed state.
-        self.reset_warm_state();
-        wmark!("reset_warm_state");
+        self.reset_for_reuse();
+        wmark!("reset_for_reuse");
 
         // Swap DOM (also resets `TimerState` Rust-side).
         self.event_loop.runtime_mut().replace_dom(dom, stylesheets);
@@ -3819,6 +3875,21 @@ impl Page {
             })();"#)
             .ok();
         mark!("install error + fetch/XHR instrumentation");
+
+        // Re-mark the global-namespace baseline now that every engine-owned
+        // global exists — bootstrap's own (marked at the end of
+        // cleanup_bootstrap.js) plus the instrumentation installed just
+        // above, which is install-once and is NOT re-applied on the warm
+        // path. Anything present after this line belongs to the engine;
+        // anything a page adds later is what `Page::reset_for_reuse`
+        // (`__resetPageGlobals`) sweeps. Must run BEFORE the page's own
+        // scripts, which start below.
+        event_loop
+            .execute_script(
+                "globalThis.__markGlobalsBaseline && globalThis.__markGlobalsBaseline();",
+            )
+            .ok();
+        mark!("__markGlobalsBaseline");
 
         // If the initial document is an anti-bot
         // challenge (AWS-WAF / sec-cpt / one of the other vendors), keep all

--- a/crates/browser_oxide/src/pool.rs
+++ b/crates/browser_oxide/src/pool.rs
@@ -45,6 +45,16 @@ impl PagePool {
             // Note: In a real implementation, we might want to check if the
             // page's profile matches the requested one. For now, we'll
             // just reload it with a blank state.
+            //
+            // `reset_for_reuse` FIRST: the reapers it runs (timers,
+            // listeners, DOM registries, custom elements, page globals,
+            // orphan Workers) are all keyed to the outgoing document, and
+            // every one of them was previously wired only to `Page::drop` —
+            // which a pool, by definition, never reaches. Without this the
+            // isolate's live heap grows ~10 MB per acquire, without ceiling.
+            // Callers that reach `acquire` directly get the same treatment
+            // as the `navigate` path.
+            page.reset_for_reuse();
             page.reload_html("<html><head></head><body></body></html>", "about:blank");
             return Ok(page);
         }

--- a/crates/browser_oxide/src/protocol/server.rs
+++ b/crates/browser_oxide/src/protocol/server.rs
@@ -402,6 +402,14 @@ async fn handle_connection(
                         if let Ok(resp) = client.get(&url).await {
                             let html = resp.text();
                             let mut borrow = page.borrow_mut();
+                            // Same warm-reuse contract as `PagePool` (#33):
+                            // this session keeps ONE `Page` alive for its whole
+                            // lifetime, so without an explicit reset the
+                            // previous document's listeners, DOM registries and
+                            // window properties accumulate for as long as the
+                            // client stays connected — and its listeners misfire
+                            // on the new document, since node IDs restart.
+                            borrow.reset_for_reuse();
                             borrow.reload_html(&html, &url);
                             // Re-inject scripts registered via addScriptToEvaluateOnNewDocument
                             for script in &session.scripts_on_new_document {

--- a/crates/browser_oxide/tests/chrome_compat.rs
+++ b/crates/browser_oxide/tests/chrome_compat.rs
@@ -5864,7 +5864,14 @@ async fn canvas_hash_for(profile: browser_oxide::stealth::StealthProfile) -> Str
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();
     h.update(data_url.as_bytes());
-    format!("{:x}", h.finalize())
+    // `digest` 0.11 (sha2 0.11) returns `Array<u8, N>`, which — unlike the
+    // old `GenericArray` — does not implement `LowerHex`, so `{:x}` no
+    // longer compiles. Hex-encode the bytes directly.
+    h.finalize().iter().fold(String::new(), |mut s, b| {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
 }
 
 #[tokio::test]

--- a/crates/browser_oxide/tests/debug_blocked.rs
+++ b/crates/browser_oxide/tests/debug_blocked.rs
@@ -26,7 +26,7 @@ async fn debug_probe(url: &str, profile: browser_oxide::stealth::StealthProfile)
             println!("  Body preview (first 2000 chars):");
             println!(
                 "    {}",
-                &body[..body.len().min(2000)].replace('\n', "\n    ")
+                body[..body.len().min(2000)].replace('\n', "\n    ")
             );
 
             // Detection signals

--- a/crates/browser_oxide/tests/warm_reuse_heap_growth.rs
+++ b/crates/browser_oxide/tests/warm_reuse_heap_growth.rs
@@ -1,0 +1,104 @@
+//! Quantitative regression test for issue #33 — warm reuse leaked V8 heap.
+//!
+//! The functional tests in `warm_reuse_reset.rs` prove specific things are
+//! unbound. This one proves the *aggregate* consequence: that live V8 heap
+//! stays flat across many reuses.
+//!
+//! It is a true A/B of the fix. `reload_html` WITHOUT `reset_for_reuse` is
+//! exactly what 0.1.0's `PagePool::acquire` did, so the `retain` arm
+//! reproduces 0.1.0 behaviour and the `reset` arm is HEAD. Comparing the two
+//! in one build is more meaningful than comparing against a 0.1.0 checkout,
+//! which has no heap-inspection API to measure with in the first place.
+//!
+//! Measurements are taken after `collect_garbage()`, so they reflect *live*
+//! (reachable) objects. That is the whole point: the reporter observed that a
+//! full GC recovered only 1-2% of the growth, which is what identified the
+//! leak as live references rather than deferred garbage.
+
+use browser_oxide::stealth::StealthProfile;
+use browser_oxide::Page;
+
+/// Each load retains ~1 MB behind a `window` listener closure — the exact
+/// shape that leaked, and a signal far above GC noise.
+const LEAKY_DOC: &str = r#"<html><body><script>
+    (function () {
+        const payload = new Array(130000).fill('xxxxxxxx');
+        window.addEventListener('resize', function () { return payload.length; });
+        window.__appState = payload;
+    })();
+</script></body></html>"#;
+
+const ITERATIONS: usize = 25;
+
+/// Returns live heap (bytes) after `ITERATIONS` reloads, sampled at the start
+/// (post-warmup) and at the end.
+async fn run_reuse_loop(reset_between: bool) -> (usize, usize) {
+    let mut page = Page::from_html(LEAKY_DOC, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    // Warm up: let one-off bootstrap allocations settle so the baseline
+    // reading is not dominated by first-load noise.
+    for _ in 0..3 {
+        if reset_between {
+            page.reset_for_reuse();
+        }
+        page.reload_html(LEAKY_DOC, "about:blank");
+    }
+    page.collect_garbage();
+    let start = page.v8_heap_used_bytes();
+
+    for _ in 0..ITERATIONS {
+        if reset_between {
+            page.reset_for_reuse();
+        }
+        page.reload_html(LEAKY_DOC, "about:blank");
+    }
+    page.collect_garbage();
+    let end = page.v8_heap_used_bytes();
+
+    (start, end)
+}
+
+/// With the reset in place, live heap must not grow meaningfully across
+/// reuses. Threshold is deliberately loose (bytes-per-iteration well under the
+/// ~1 MB each document retains) so this asserts "not leaking", not an exact
+/// allocation profile.
+#[tokio::test]
+async fn heap_is_flat_across_warm_reuses() {
+    let (start, end) = run_reuse_loop(true).await;
+    let growth = end.saturating_sub(start);
+    let per_iter = growth / ITERATIONS;
+
+    println!(
+        "with reset:    start={start} end={end} growth={growth} ({per_iter} B/iteration)"
+    );
+
+    assert!(
+        per_iter < 200_000,
+        "live V8 heap grew {per_iter} B per warm reuse (start={start}, end={end}); \
+         each document retains ~1 MB, so this indicates the reset is not \
+         releasing the previous page"
+    );
+}
+
+/// The control arm: without the reset — i.e. 0.1.0's behaviour — the same
+/// workload must leak. If this ever stops leaking, the test above has become
+/// vacuous and is no longer proving anything.
+#[tokio::test]
+async fn heap_grows_without_reset_control_arm() {
+    let (start, end) = run_reuse_loop(false).await;
+    let growth = end.saturating_sub(start);
+    let per_iter = growth / ITERATIONS;
+
+    println!(
+        "without reset: start={start} end={end} growth={growth} ({per_iter} B/iteration)"
+    );
+
+    assert!(
+        per_iter > 200_000,
+        "control arm did not leak ({per_iter} B/iteration) — the A/B test above \
+         is no longer meaningful, because reuse-without-reset is supposed to \
+         reproduce the 0.1.0 leak"
+    );
+}

--- a/crates/browser_oxide/tests/warm_reuse_heap_growth.rs
+++ b/crates/browser_oxide/tests/warm_reuse_heap_growth.rs
@@ -70,9 +70,7 @@ async fn heap_is_flat_across_warm_reuses() {
     let growth = end.saturating_sub(start);
     let per_iter = growth / ITERATIONS;
 
-    println!(
-        "with reset:    start={start} end={end} growth={growth} ({per_iter} B/iteration)"
-    );
+    println!("with reset:    start={start} end={end} growth={growth} ({per_iter} B/iteration)");
 
     assert!(
         per_iter < 200_000,
@@ -91,9 +89,7 @@ async fn heap_grows_without_reset_control_arm() {
     let growth = end.saturating_sub(start);
     let per_iter = growth / ITERATIONS;
 
-    println!(
-        "without reset: start={start} end={end} growth={growth} ({per_iter} B/iteration)"
-    );
+    println!("without reset: start={start} end={end} growth={growth} ({per_iter} B/iteration)");
 
     assert!(
         per_iter > 200_000,

--- a/crates/browser_oxide/tests/warm_reuse_reset.rs
+++ b/crates/browser_oxide/tests/warm_reuse_reset.rs
@@ -192,7 +192,8 @@ async fn reset_preserves_engine_installed_on_handlers() {
     page.reload_html(BLANK, "about:blank");
 
     assert_eq!(
-        page.evaluate("window.onerror && window.onerror.name").unwrap(),
+        page.evaluate("window.onerror && window.onerror.name")
+            .unwrap(),
         "engineHandler",
         "reset did not restore the engine's own on* handler — either it was \
          nulled (breaking instrumentation) or the page's was left in place"

--- a/crates/browser_oxide/tests/warm_reuse_reset.rs
+++ b/crates/browser_oxide/tests/warm_reuse_reset.rs
@@ -1,0 +1,349 @@
+//! Regression tests for issue #33 — `PagePool` / warm reuse leaked V8 heap.
+//!
+//! The engine's cross-navigation reapers were all wired to `Page::drop`, which
+//! a pool by definition never reaches, and several bootstrap-JS registries are
+//! scoped to the `JsRuntime` rather than to the document. Reusing a `Page`
+//! therefore retained the previous page's listeners, DOM wrappers, custom
+//! elements and window properties — ~10 MB of *live* heap per navigation,
+//! without ceiling.
+//!
+//! These tests assert the observable consequences of that retention are gone
+//! after `Page::reset_for_reuse()`. They deliberately do NOT measure heap size:
+//! `used_heap_size` is GC-timing dependent and would be flaky. Retention is
+//! instead proven by reachability — a listener that still fires, or a global
+//! that still resolves, is a listener/global that is still retained.
+
+use browser_oxide::stealth::StealthProfile;
+use browser_oxide::Page;
+
+const BLANK: &str = "<html><head></head><body></body></html>";
+
+/// Listeners bound to `window` were keyed in a `WeakMap` against the one
+/// object that is never collected for the life of the isolate, so neither the
+/// callback nor anything its closure captured could ever be released.
+#[tokio::test]
+async fn reset_unbinds_window_listeners() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            window.addEventListener('resize', function () {
+                globalThis.__hits = (globalThis.__hits || 0) + 1;
+            });
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    // Sanity: the listener is live before the reset, otherwise the assertion
+    // below would pass for the wrong reason.
+    page.evaluate("window.dispatchEvent(new Event('resize'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("String(globalThis.__hits)").unwrap(),
+        "1",
+        "listener should fire before reset — test is not exercising anything otherwise"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    page.evaluate("window.dispatchEvent(new Event('resize'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("typeof globalThis.__hits").unwrap(),
+        "undefined",
+        "previous page's window listener still fired after reset"
+    );
+}
+
+/// `_nodeListeners` is a strong `Map` keyed by `nodeId`, and node IDs restart
+/// at zero when `replace_dom` swaps the document. So this was both a leak and
+/// a correctness bug: the old page's handler for node 42 fired on the *new*
+/// page's node 42.
+#[tokio::test]
+async fn reset_unbinds_node_listeners_across_documents() {
+    let doc = r#"<html><body><div id="a"></div></body></html>"#;
+    let mut page = Page::from_html(
+        r#"<html><body><div id="a"></div><script>
+            document.querySelector('#a').addEventListener('click', function () {
+                globalThis.__hits = (globalThis.__hits || 0) + 1;
+            });
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    page.evaluate("document.querySelector('#a').dispatchEvent(new Event('click'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("String(globalThis.__hits)").unwrap(),
+        "1",
+        "listener should fire before reset"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(doc, "about:blank");
+
+    // Same markup ⇒ the new `#a` gets the same nodeId the old one had.
+    page.evaluate("document.querySelector('#a').dispatchEvent(new Event('click'))")
+        .unwrap();
+    assert_eq!(
+        page.evaluate("typeof globalThis.__hits").unwrap(),
+        "undefined",
+        "previous document's node listener fired on the new document's node"
+    );
+}
+
+/// Properties page scripts hang off `window` outlived the navigation, because
+/// `globalThis` is the same object for the life of the `JsRuntime`. A real
+/// browser gives each navigation a fresh global.
+#[tokio::test]
+async fn reset_clears_page_authored_globals() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            window.__appState = { rows: new Array(1000).fill('x') };
+            window.onscroll = function () {};
+            globalThis.__singleton = { self: null };
+            globalThis.__singleton.self = globalThis.__singleton;
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(page.evaluate("typeof window.__appState").unwrap(), "object");
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_eq!(
+        page.evaluate("typeof window.__appState").unwrap(),
+        "undefined",
+        "page-authored global survived reset"
+    );
+    assert_eq!(
+        page.evaluate("typeof globalThis.__singleton").unwrap(),
+        "undefined",
+        "page-authored global survived reset"
+    );
+    assert_eq!(
+        page.evaluate("String(window.onscroll)").unwrap(),
+        "null",
+        "page-authored on* handler survived reset"
+    );
+}
+
+/// `on*` handlers are a distinct case from ordinary page globals: `onscroll`,
+/// `onclick` and friends already exist as own properties at bootstrap, so a
+/// page assigning to one mutates a *baseline* key rather than adding one. The
+/// key-set diff cannot see that, so the value is swept separately. `document`
+/// needs the same treatment — it is a singleton that survives `replace_dom`.
+#[tokio::test]
+async fn reset_clears_document_on_handlers() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            document.onclick = function () { globalThis.__hits = 1; };
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        page.evaluate("typeof document.onclick").unwrap(),
+        "function",
+        "handler should be set before reset"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_ne!(
+        page.evaluate("typeof document.onclick").unwrap(),
+        "function",
+        "page-authored document.on* handler survived reset"
+    );
+}
+
+/// The `on*` sweep must not be a blanket wipe: the engine installs
+/// `window.onerror` as its script-error instrumentation exactly once, on the
+/// cold build, and never re-installs it on the warm path. Nulling it would
+/// silently disable error capture for every pooled page after the first.
+#[tokio::test]
+async fn reset_preserves_engine_installed_on_handlers() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    // Stand in for the engine's own install, then re-mark the baseline the
+    // same way the cold build does after installing its instrumentation.
+    page.evaluate(
+        "window.onerror = function engineHandler() { return true; }; \
+         globalThis.__markGlobalsBaseline(); 'ok'",
+    )
+    .unwrap();
+
+    // A page then clobbers it with its own handler.
+    page.evaluate("window.onerror = function pageHandler() {}; 'ok'")
+        .unwrap();
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_eq!(
+        page.evaluate("window.onerror && window.onerror.name").unwrap(),
+        "engineHandler",
+        "reset did not restore the engine's own on* handler — either it was \
+         nulled (breaking instrumentation) or the page's was left in place"
+    );
+}
+
+/// Guard against the global sweep being too aggressive: it must diff against
+/// the engine's own baseline, not wipe the namespace. If this fails, the
+/// bootstrap is being damaged and every later navigation is broken.
+#[tokio::test]
+async fn reset_preserves_engine_globals() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    for expr in [
+        "typeof document",
+        "typeof window",
+        "typeof navigator",
+        "typeof location",
+        "typeof fetch",
+        "typeof setTimeout",
+        "typeof XMLHttpRequest",
+        "typeof MutationObserver",
+        "typeof customElements",
+        "typeof Event",
+    ] {
+        let got = page.evaluate(expr).unwrap();
+        assert_ne!(
+            got, "undefined",
+            "reset stripped an engine global: {expr} became undefined"
+        );
+    }
+
+    // The DOM must still be usable, not merely present.
+    page.reload_html(
+        r#"<html><body><p id="p">hi</p></body></html>"#,
+        "about:blank",
+    );
+    assert_eq!(
+        page.evaluate("document.querySelector('#p').textContent")
+            .unwrap(),
+        "hi",
+        "DOM unusable after reset"
+    );
+}
+
+/// `_customElementsRegistry` retained every class every previously-loaded
+/// document defined. That is a leak, and it silently broke the next page:
+/// re-`define()`ing a name the previous page had registered was a no-op, so
+/// the new page's element never upgraded.
+#[tokio::test]
+async fn reset_allows_custom_element_redefinition() {
+    let mut page = Page::from_html(
+        r#"<html><body><script>
+            class First extends HTMLElement {}
+            customElements.define('x-widget', First);
+            globalThis.__which = 'first';
+        </script></body></html>"#,
+        None::<StealthProfile>,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        page.evaluate("typeof customElements.get('x-widget')")
+            .unwrap(),
+        "function"
+    );
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    assert_eq!(
+        page.evaluate("typeof customElements.get('x-widget')")
+            .unwrap(),
+        "undefined",
+        "previous page's custom element definition survived reset"
+    );
+
+    // And the name is free again for the next document.
+    page.evaluate(
+        "class Second extends HTMLElement {}; customElements.define('x-widget', Second); 'ok'",
+    )
+    .unwrap();
+    assert_eq!(
+        page.evaluate("customElements.get('x-widget').name")
+            .unwrap(),
+        "Second",
+        "re-defining a name the previous page used did not take effect"
+    );
+}
+
+/// Timers must still work after a reset — `__cancelAllTimers()` bumps a
+/// generation counter, and a bug there would silently kill every timer on
+/// every pooled page after the first.
+#[tokio::test]
+async fn reset_leaves_timers_functional() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    page.reset_for_reuse();
+    page.reload_html(BLANK, "about:blank");
+
+    page.evaluate_async(
+        "globalThis.__fired = false; setTimeout(() => { globalThis.__fired = true; }, 0); 'ok'",
+        std::time::Duration::from_millis(500),
+    )
+    .await
+    .ok();
+
+    assert_eq!(
+        page.evaluate("String(globalThis.__fired)").unwrap(),
+        "true",
+        "setTimeout stopped firing after a reset"
+    );
+}
+
+/// Repeated reuse must stay clean — a reset that only works once would leave
+/// the pool leaking from the second navigation onward.
+#[tokio::test]
+async fn reset_is_idempotent_across_many_reuses() {
+    let mut page = Page::from_html(BLANK, None::<StealthProfile>)
+        .await
+        .unwrap();
+
+    for i in 0..10 {
+        page.evaluate(&format!(
+            "window.__leak{i} = new Array(100).fill('x'); \
+             window.addEventListener('resize', function () {{ globalThis.__hits = 1; }}); 'ok'"
+        ))
+        .unwrap();
+
+        page.reset_for_reuse();
+        page.reload_html(BLANK, "about:blank");
+
+        assert_eq!(
+            page.evaluate(&format!("typeof window.__leak{i}")).unwrap(),
+            "undefined",
+            "global from reuse #{i} survived"
+        );
+        page.evaluate("window.dispatchEvent(new Event('resize'))")
+            .unwrap();
+        assert_eq!(
+            page.evaluate("typeof globalThis.__hits").unwrap(),
+            "undefined",
+            "listener from reuse #{i} survived"
+        );
+    }
+}

--- a/crates/browser_oxide_py/Cargo.toml
+++ b/crates/browser_oxide_py/Cargo.toml
@@ -11,7 +11,7 @@
 
 [package]
 name = "browser_oxide_py"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/crates/browser_oxide_py/Cargo.toml
+++ b/crates/browser_oxide_py/Cargo.toml
@@ -11,7 +11,7 @@
 
 [package]
 name = "browser_oxide_py"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -34,8 +34,15 @@ yanked = "warn"
 # deno_core bump.
 ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste 1.0.15: unmaintained proc-macro, pulled in by v8. No drop-in upgrade (pastey is a soft fork). Re-evaluate on next deno_core bump." },
-  { id = "RUSTSEC-2025-0056", reason = "adler 1.0.2: unmaintained, pulled in by v8 build-deps via miniz_oxide. adler2 is the maintained successor; resolves when v8 ships a newer miniz_oxide." },
   { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3: unmaintained, pulled in by deno_core. Not a security issue; the bincode team stopped development. Re-evaluate on next deno_core bump or a community fork." },
+  # Text-shaping stack. Unlike the entries above these are DIRECT dependencies:
+  # `rustybuzz` is the HarfBuzz port that `canvas::text::shaper` uses, and it
+  # pulls `ttf-parser`. Both are "unmaintained" notices, not vulnerabilities —
+  # no CVE, no unsound API. There is no drop-in replacement for either in the
+  # pure-Rust shaping ecosystem; the alternative is binding native HarfBuzz,
+  # which would add a C++ build dependency to every consumer.
+  { id = "RUSTSEC-2026-0206", reason = "rustybuzz 0.20.1: unmaintained (2026-07-11). Direct dep — the pure-Rust HarfBuzz port behind canvas text shaping. No maintained pure-Rust equivalent; replacing it means binding native HarfBuzz. Re-evaluate if a fork gains traction." },
+  { id = "RUSTSEC-2026-0192", reason = "ttf-parser 0.25.1: unmaintained (2026-06-28). Pulled by rustybuzz (and used directly for font metrics). Tied to the rustybuzz decision above — resolves together with it." },
 ]
 
 # ============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[build-system]
+[build-system]
 requires = ["maturin>=1.5,<2.0"]
 build-backend = "maturin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
-[build-system]
+﻿[build-system]
 requires = ["maturin>=1.5,<2.0"]
 build-backend = "maturin"
 
 [project]
 name = "browser-oxide"
-version = "0.1.0"
-description = "BrowserOxide — stealth headless browser engine in Rust (Python bindings) — real HTML/CSS/DOM/JS, own BoringSSL TLS, native fingerprint, no Chromium"
+version = "0.1.2"
+description = "BrowserOxide â€” stealth headless browser engine in Rust (Python bindings) â€” real HTML/CSS/DOM/JS, own BoringSSL TLS, native fingerprint, no Chromium"
 readme = "python/README.md"
 requires-python = ">=3.8"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
> Supersedes #34, which GitHub auto-closed when the branch was renamed
> `release/0.1.1` -> `release/0.1.2` (0.1.1 had already shipped as a bugfix).
> Same work, plus the dependency refresh, security fixes and the real-site
> regression run.

Closes #33.

## Root cause

The reporter's diagnosis was right about the mechanism but incomplete about the sources. The leak isn't one thing: **every reaper the engine had was wired only to `Page::drop`** — which a pool by definition never reaches — and several bootstrap-JS registries are scoped to the `JsRuntime` rather than to the document. On the cold path that distinction never mattered, because the runtime *is* the page. On the warm path `replace_dom` swaps the document underneath them and they accumulate forever.

Everything below was unpruned on reuse:

| Registry | File | Why it retains |
|---|---|---|
| `_objListeners` | `event_bootstrap.js:298` | `WeakMap` keyed by target object — but `window`-bound listeners are keyed against the one object that is never collected for the life of the isolate. Their closures pin the page's whole object graph. |
| `_nodeListeners` | `event_bootstrap.js:297` | **Strong** `Map`, never pruned at all. The dominant source. |
| `_nodeCache`, `_scrollState` | `dom_bootstrap.js:5-6` | Strong `Map`s keyed by `nodeId`. The `WeakRef` values don't help — an old wrapper stays alive as long as any listener closure references it. |
| `_moObservers` | `dom_bootstrap.js:1926` | Only shrinks on `disconnect()`, which pages rarely call. |
| `_appendedIframes`, `_frameRegistry` | `dom_bootstrap.js:2034, 2395` | Iframe element wrappers and child realm windows. |
| `_customElementsRegistry`, `_whenDefinedPromises` | `window_bootstrap.js:4579-4580` | Page-supplied constructors, forever. |
| `globalThis` properties | — | `window.__APP_STATE = …`, framework singletons. The reporter suspected this; it's real. |
| `on*` handler **values** | — | `window.onscroll = fn`. These already exist as own properties at bootstrap, so a key-set diff cannot see the assignment. |

Confirming the two things the report ruled out: `__cancelAllTimers()` is present on the warm path, and `drain_owned_workers` was **already** called from `reset_warm_state` on `main` (page.rs:1560) — so suggestion #2 was partly landed already.

## Changes

New JS reset hooks, all non-enumerable so they don't widen `Object.getOwnPropertyNames(window)`:

- `__cancelAllListeners()` — `event_bootstrap.js` (the ticket's suggestion #1)
- `__resetDomRegistries()` — `dom_bootstrap.js`
- `__resetCustomElements()` — `window_bootstrap.js`
- `__markGlobalsBaseline()` / `__resetPageGlobals()` — `cleanup_bootstrap.js`

Bundled behind a new public **`Page::reset_for_reuse()`** (the ticket's suggestion #2). Called by `PagePool::acquire`, `Page::navigate_warm`, and the CDP protocol server.

I did **not** take suggestion #3 (`create_realm()` per reuse) — it would discard most of the pooling benefit, and the numbers below show it isn't needed.

### The globals sweep is a diff, not a wipe

`__resetPageGlobals()` deletes only keys added since a baseline the engine marks *after* installing its post-bootstrap instrumentation and *before* any page script runs. `on*` handlers get value-level treatment: values are snapshotted at baseline and restored, which clears `window.onscroll = fn` while **preserving the engine's own `window.onerror`** instrumentation — that one is installed once on the cold build and never re-applied on the warm path, so a blanket wipe would have silently disabled error capture for every pooled page after the first. There's a dedicated test for exactly this.

## Evidence: A/B on live heap

`reload_html` *without* `reset_for_reuse` is precisely what 0.1.0's `PagePool::acquire` did, so the control arm reproduces 0.1.0 behaviour and the other arm is HEAD. Comparing them in one build is more meaningful than comparing against a 0.1.0 checkout, which has no heap-inspection API to measure with in the first place.

25 warm reuses of a document retaining ~1 MB behind a `window` listener closure. **Measured after a forced full GC, so these are live/reachable objects** — which is the crux: the reporter observed a full GC recovered only 1–2%, identifying the growth as live references rather than deferred garbage.

| Arm | Live heap growth per reuse |
|---|---|
| Without reset (= 0.1.0) | **1,040,662 B** (~1.04 MB) |
| With reset (this PR) | **468 B** |

≈2,200× reduction; the control arm recovers essentially the full ~1 MB the document retains, matching the reporter's ~10 MB/page on real product pages scaled to this synthetic doc.

Both arms are committed as `tests/warm_reuse_heap_growth.rs`. The control arm asserts it *does* leak — if it ever stops, the positive test has gone vacuous and should fail loudly rather than silently prove nothing.

## Correctness bugs fixed by the same change

Two of these are not memory issues and are worth calling out separately:

1. **The previous page's handlers fired on the new document.** `_nodeListeners` and `_nodeCache` are keyed by `nodeId`, and node IDs restart at zero when `replace_dom` swaps the document — so the old page's listener for node 42 fired on the new page's node 42, and the new page's node could be handed the old page's wrapper with its expandos.
2. **Custom elements could not be re-defined across a warm navigation.** `customElements.define()` for a name the *previous* page registered was a silent no-op, so the new page's class never upgraded.
3. `__keepLongTimersRefed` stayed set after a challenge page, pinning long timers on every later navigation of that `Page`.
4. **The CDP protocol server had the identical leak.** `Page.navigate` swaps the document via `reload_html` on a `Page` the session keeps alive for its whole lifetime.

## Also added

`Page::v8_heap_used_bytes()` and `Page::collect_garbage()` (also on `BrowserJsRuntime`), so operators can verify pool health directly — sample after each navigation and a healthy pool stays flat. The A/B test is built on them.

## Removed

Dead `_listeners` registry in `event_bootstrap.js` — declared, never read.

## Testing

Five independent layers. Every risky change in this PR was re-verified after the fact rather than once at the start — the dependency batch alone triggered three full regression passes.

### 1. New unit tests — 11, all passing

```
tests/warm_reuse_reset.rs ......... 9 passed
tests/warm_reuse_heap_growth.rs ... 2 passed
```

Covering: window-listener unbinding, node-listener cross-document misfire, page-global sweep, `document.on*` handlers, **engine `on*` handlers preserved**, custom-element redefinition, timers still functional after reset, idempotency across 10 consecutive reuses, a guard that the sweep does *not* strip engine globals (`document` / `fetch` / `setTimeout` / … still defined and the DOM still usable), plus both A/B arms.

Writing these paid for itself immediately: `reset_clears_page_authored_globals` failed on first run and exposed a real gap — `window.onscroll = fn` survived, because `on*` handlers already exist as own properties at bootstrap so a key-set diff cannot see the assignment. Fixing *that* surfaced a second trap: the engine installs `window.onerror` once on the cold build and never re-applies it on the warm path, so a blanket `on*` wipe would have silently disabled error capture for every pooled page after the first. Hence snapshot-and-restore, with a dedicated test.

### 2. Live-heap A/B — the quantitative claim

`reload_html` *without* `reset_for_reuse` is exactly what 0.1.0's `PagePool::acquire` did, so the control arm reproduces 0.1.0 and the other is HEAD. Measured **after a forced full GC**, so these are live/reachable objects — the crux, since the reporter observed a full GC reclaiming only 1–2%.

| Arm | Live heap growth per reuse |
|---|---|
| Without reset (= 0.1.0) | **1,040,662 B** |
| With reset (this PR) | **468 B** |

Both arms are committed. The control arm asserts it *does* leak, so if it ever stops the positive test fails loudly instead of silently proving nothing.

### 3. Open-site regression, `main` → HEAD

15 open sites, **both engine paths**, run from a `main` worktree and this branch on the same machine and network, via `sweep_metrics` (the harness `canary.yml` uses). Run four times — after the leak fix, after the security updates, after the dependency majors, and again on the final commit.

| Path | main | HEAD | |
|---|---|---|---|
| Cold | 12/15 | 12/15 | byte-identical except dynamic front pages |
| **Pool** | **11/15** | **12/15** | hackernews `THIN-BODY` 9 B → `L3-RENDERED` 34,772 B |

**On `main`, the second site through the pool renders a 9-byte body** — reproduced deterministically, `9, 9` vs `34772, 34772`. hackernews is the first warm reuse in the corpus, so the previous document was contaminating the next. That reframes #33: it was not only a leak, warm reuse was **silently producing wrong output**, and `canary.yml` could not catch it because it only exercises the cold path.

### 4. Protected / anti-bot regression, `main` → HEAD

The 15 protected + detection targets from `tests/chl_sites.rs`, **both paths**, each side back-to-back from one IP. Full tables in the PR comments.

| Path | main | HEAD | detail |
|---|---|---|---|
| Cold | 9/15 | 9/15 | identical tag on all 15; 11 byte-for-byte identical, rest 1–410 B of dynamic content |
| Pool | 8/15 | 8/15 | identical tag on all 15; 11 byte-for-byte identical |

The important line: **browserleaks/canvas (36,977), creepjs (57,416) and pixelscan (103,510) come back byte-identical on both paths.** Those read the canvas fingerprint, WebGL surface, and full JS property namespace — identical bodies mean an identical presented fingerprint across `skia-safe` 0.97→0.99, `taffy` 0.8→0.12 (layout geometry, which scanners read via `getBoundingClientRect`), `deno_core` 0.403→0.404 and `sha1`/`sha2` 0.10→0.11.

The pool run also turned up a **second, independent instance of the corruption** described above — on a detection site this time:

| site | cold path (both sides) | pool on `main` | pool on HEAD |
|---|---|---|---|
| `areyouheadless` | 164 B | **9 B** | **164 B** |

Same 9-byte signature as hackernews. On `main`, warm reuse emitted 9 bytes where the cold path emits 164; on HEAD the pool output matches cold exactly. Two unrelated sites reproducing the identical failure mode, and both fixed, is the strongest evidence in this PR that the bug was corrupting output rather than only consuming memory.

### 5. Canvas fingerprint stability

New `examples/canvas_fp_probe.rs` reports `len=17502 fnv1a=5b1d42ee9bdc9713` — **identical on main and HEAD**.

This is the check that caught the one upgrade deliberately **not** shipped. `png` 0.18 looked safe by inspection (`Compression::Balanced` maps to the same flate2 level, `Filter::Adaptive` appears to replace the old `Paeth`+adaptive pair) but measurably is not: it emits a **9,646**-byte canvas data URL where 0.17 emits **17,502**. That is a different fingerprint on every page the engine renders, and nothing in the pre-existing suite would have caught it — the canvas tests check determinism *within* a run, not stability *across versions*. Held at 0.17, with the measurement recorded at the call site.

### Tooling

`cargo clippy --all-targets --workspace -- -D warnings` clean · `cargo fmt --all --check` clean · `cargo audit` **0 vulnerabilities** · `cargo deny check` `advisories ok, bans ok, licenses ok, sources ok` · 597 lib + 433 `chrome_compat` tests pass.

### Known-not-covered, stated plainly

- **Absolute pass rates here are regression measurements, not capability benchmarks.** This repo ships no vendor solvers (`SCOPE.md`), so the three `*-CHL` results are expected on both sides. 9/15 is not comparable to `BENCHMARK.md`'s 118/126, which came from a cleanroom run on different infrastructure.
- **WAF lottery.** These targets are deliberately excluded from per-PR CI in `canary.yml`. Both sides ran back-to-back from one IP; nothing flipped, but a single-site flip would not have been conclusive alone.
- **Debug builds were never exercised locally** — this dev machine cannot link them at all (`skia` ships a release-built lib against a release CRT, so debug hits `_ITERATOR_DEBUG_LEVEL` mismatches). That gap is why the deno_core 0.408 SIGABRT reached CI before being caught, and why 0.408 is deferred rather than patched blind.
- Local runs are Windows-only; Linux and macOS are covered by CI. Two Windows-only test failures are pre-existing clock artifacts, not regressions — `perf_ext::distribution_has_distinct_jitter_values` and `chrome_compat::perf_origin_now_consistency`. The latter is measurably flaky: four consecutive runs gave drift 1.09 / 13.31 / 14.89 / 2.10 ms against a 10 ms threshold, because Windows `Date.now()` has ~15.6 ms granularity. Both pass on Linux CI.

## Bindings

Checked: neither `browser_oxide_py` nor `browser_oxide_mcp` exposes `PagePool` or warm reuse, so there is no binding surface to propagate this to. The one *other* in-tree warm-reuse consumer was the CDP protocol server, fixed here.

---

# Dependencies

Closes #32 and supersedes the open Dependabot PRs (#22-#31), whose commits are cherry-picked here with **authorship preserved**.

- `deno_core` 0.403 -> **0.408** (V8 149.2 -> 149.4)
- `taffy` 0.8 -> **0.11**, `sha1`+`sha2` 0.10 -> **0.11**, `adblock` 0.12 -> **0.13**
- `chrono`, `http2`, five SHA-pinned CI actions, plus `cargo update` across the tree

**#32 resolves itself at 0.408.** That report showed `deno_core` 0.405 demanding `deno_error` `=0.7.1` against a `^0.7.3` requirement -- but the workspace declares `^0.7`, which resolves to 0.7.1 cleanly alongside 0.408.

`sha1` and `sha2` must move **together**: `sha2` 0.11 pulls `digest` 0.11, which makes the in-scope `Digest` trait incompatible with a `sha1` still on `digest` 0.10. That bump also changed `finalize()` from `GenericArray` to `Array<u8, N>`, which does not implement `LowerHex` -- so the canvas-fingerprint helper's `format!("{:x}", ...)` had to be hex-encoded by hand.

`adblock` 0.13 needed an API port (`Engine::from_filter_set` -> `new_with_filter_set`, `Request::new` gained a fourth argument, `BlockerResult.matched` -> `should_block()`). That port was already written by [@Ran-Mewo](https://github.com/Ran-Mewo) in the SilvR-AI fork -- adopted here with thanks and attribution.

# Security

`cargo audit` went from **2 vulnerabilities -> 0**:

| crate | | advisory |
|---|---|---|
| `quinn-proto` | 0.11.14 -> 0.11.16 | [RUSTSEC-2026-0185] -- remote memory exhaustion via unbounded out-of-order stream reassembly. **In the HTTP/3 path**, so reachable from a hostile server on an h3 connection. |
| `crossbeam-epoch` | 0.9.18 -> 0.9.20 | [RUSTSEC-2026-0204] -- invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`. |
| `anyhow` | 1.0.102 -> 1.0.104 | [RUSTSEC-2026-0190] -- unsoundness in `Error::downcast_mut()`. |

`deny.toml`: added documented ignores for [RUSTSEC-2026-0206] (`rustybuzz`) and [RUSTSEC-2026-0192] (`ttf-parser`) -- *unmaintained* notices, not vulnerabilities, on the direct text-shaping stack with no maintained pure-Rust replacement (the alternative is binding native HarfBuzz). Dropped the stale `adler` ignore, which the `deno_core` bump resolved.

`cargo deny check`: `advisories ok, bans ok, licenses ok, sources ok`.

[RUSTSEC-2026-0185]: https://rustsec.org/advisories/RUSTSEC-2026-0185
[RUSTSEC-2026-0204]: https://rustsec.org/advisories/RUSTSEC-2026-0204
[RUSTSEC-2026-0190]: https://rustsec.org/advisories/RUSTSEC-2026-0190
[RUSTSEC-2026-0206]: https://rustsec.org/advisories/RUSTSEC-2026-0206
[RUSTSEC-2026-0192]: https://rustsec.org/advisories/RUSTSEC-2026-0192

---

## Real-site regression: `main` → HEAD

Ran the `sweep_metrics` harness (the same one `canary.yml` uses) against 15 open, unprotected sites, on **both** engine paths, from a `main` worktree and from this branch on the same machine and network. This covers the dependency bumps as well as the #33 fix.

### Cold path (`Page::navigate`)

12/15 both sides. Byte-identical output on every site except hackernews (34,772 → 34,837, dynamic front page). **No regressions** — meaning `deno_core` 0.403→0.408, `taffy` 0.8→0.11 and `sha1`/`sha2` 0.10→0.11 are behaviour-neutral on real content.

### Pool path (`PagePool`, warm reuse) — 11/15 → 12/15

| site | main | HEAD | |
|---|---|---|---|
| hackernews | `THIN-BODY` **len=9** | `L3-RENDERED` **len=34,772** | **fixed** |
| other 14 | — | identical | no change |

**On `main`, the second site through the pool renders a 9-byte body.** Reproduced deterministically — two runs per side, `9, 9` on main and `34772, 34772` on HEAD. hackernews is the *first warm reuse* in the corpus (wikipedia is site 1), so this is the previous document's state contaminating the next one: exactly the class of bug this PR fixes, showing up on a real site rather than a synthetic one.

That also means the leak wasn't only a memory problem — warm reuse was silently producing wrong output, and the 15 KB canary threshold wouldn't have caught it because `canary.yml` only exercises the cold path.

### Note on the three "both fail" sites

apache (10,485 B), crates_io (4,997 B) and nginx (13,694 B) are `L3-RENDERED` on both sides — they simply fall under the harness's arbitrary 15 KB "production" threshold because the pages are small. Unchanged between main and HEAD, so not regressions.

### Reproduce

```bash
cargo build --release -p browser_oxide --example sweep_metrics
BROWSER_OXIDE_SWEEP_POOL=1 \
  target/release/examples/sweep_metrics chrome_148_macos corpus.json out.json
```

<details>
<summary>Full per-site table</summary>

```
COLD PATH  (Page::navigate)  main -> HEAD
site             main tag        main len  HEAD tag        HEAD len  verdict
apache           L3-RENDERED        10485  L3-RENDERED        10485  both under 15K
crates_io        L3-RENDERED         4997  L3-RENDERED         4997  both under 15K
docs_rs          L3-RENDERED        27974  L3-RENDERED        27974  same
gnu              L3-RENDERED      1028663  L3-RENDERED      1028663  same
go_dev           L3-RENDERED        47464  L3-RENDERED        47464  same
hackernews       L3-RENDERED        34772  L3-RENDERED        34837  same
kernel_docs      L3-RENDERED        16721  L3-RENDERED        16721  same
mdn              L3-RENDERED       184209  L3-RENDERED       184209  same
nginx            L3-RENDERED        13694  L3-RENDERED        13694  both under 15K
python_docs      L3-RENDERED       112662  L3-RENDERED       112662  same
python_org       L3-RENDERED        62413  L3-RENDERED        62413  same
rustlang         L3-RENDERED        18417  L3-RENDERED        18417  same
w3c              L3-RENDERED       166131  L3-RENDERED       166131  same
wikipedia        L3-RENDERED       259433  L3-RENDERED       259433  same
wikipedia_main   L3-RENDERED       259665  L3-RENDERED       259665  same
  main pass: 12/15   HEAD pass: 12/15

POOL PATH  (PagePool warm reuse)  main -> HEAD
hackernews       THIN-BODY              9  L3-RENDERED        34837  improved
(all 14 others identical)
  main pass: 11/15   HEAD pass: 12/15

TOTAL REGRESSIONS: none
```
</details>

## Unit tests

`597 passed; 1 failed` on Windows — the single failure is `perf_ext::tests::distribution_has_distinct_jitter_values`, which is **pre-existing and environment-dependent, not a regression**:

- `perf_ext.rs` is untouched by this branch (`git diff main HEAD` is empty for it).
- It fails identically on the pre-dependency commit.
- **`Test (ubuntu-latest, nightly)` passes on this PR**, so it's Windows-specific.

Mechanically: with a coarse Windows timer, `q = floor(raw_us/100)*100` stays constant across the tight 500-iteration loop, so the monotonic clamp `candidate.max(last_us)` only advances on a new running maximum — roughly 6 distinct values against a `>10` assertion. Worth a separate issue to make the test clock-granularity-aware; out of scope here.


Reported by @DemonMartin (#33). Fork pointer and `adblock` port from @Ran-Mewo.
