### PR TITLE
0.1.3: deno_core 0.404 -> 0.408 (#37)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,12 +30,16 @@ jobs:
           [ -n "$VERSION" ] || { echo "::error::could not parse [workspace.package] version"; exit 1; }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "workspace version: $VERSION"
-      - name: Require a CHANGELOG section for this version
-        run: |
-          V='${{ steps.ver.outputs.version }}'
-          if grep -qE "^##+ \[?${V//./\\.}\]?" CHANGELOG.md; then
-            echo "CHANGELOG has a section for $V ✔"
-          else
-            echo "::error file=CHANGELOG.md::no '## [$V]' section found in CHANGELOG.md"
-            exit 1
-          fi
+      - name: Require a release-ready CHANGELOG section for this version
+        # Run the SAME validator the release workflows run, rather than a
+        # separate grep for the header. A header-only check passes while the
+        # release still fails, because `extract-release-notes.sh` additionally
+        # requires a `> subtitle` blockquote and at least one `### ` heading.
+        #
+        # That gap is not hypothetical: v0.1.2 passed this gate, was tagged and
+        # published to crates.io, and then `Release MCP binary` failed at
+        # "Generate release notes from CHANGELOG" with
+        #   No '> subtitle' blockquote found under '## [0.1.2]'
+        # A post-tag failure is the expensive kind — the tag is already public.
+        # Validating with the real script means the PR catches it instead.
+        run: bash .github/scripts/extract-release-notes.sh --check '${{ steps.ver.outputs.version }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,14 @@ jobs:
       # tests (see CLAUDE.md). Network-bound and live anti-bot tests are
       # `#[ignore]` and not run here.
       - name: Test (single-threaded — V8 constraint)
-        run: cargo test --workspace --no-fail-fast -- --test-threads=1
+        # `--nocapture` matters for more than verbosity here. libtest captures
+        # each test's stdout/stderr and only replays it on failure — so when a
+        # test *aborts* the process (V8 FATAL, or a panic in a V8 callback that
+        # cannot unwind), the captured reason dies with it and the log shows a
+        # bare `signal: 6, SIGABRT` with no diagnosis. That is exactly what
+        # happened investigating #37. Streaming output unbuffered means the last
+        # thing printed before an abort is the abort's own message.
+        run: cargo test --workspace --no-fail-fast -- --test-threads=1 --nocapture
         env:
           CARGO_INCREMENTAL: "0"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.3]
 
+> Lands the `deno_core` 0.408 bump deferred from 0.1.2 — a V8 isolate must now be
+> constructed inside an entered tokio runtime or the process aborts — and makes
+> the V8 heap ceiling environment-tunable.
+
 ### Fixed
 - **A V8 isolate constructed outside a tokio runtime aborted the process**
   ([#37](https://github.com/yfedoseev/browser_oxide/issues/37)). `deno_core`
@@ -59,6 +63,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   including the debug jobs that previously aborted.
 
 ## [0.1.2]
+
+> Fixes an unbounded V8 heap leak in `PagePool` warm reuse that was also silently
+> corrupting render output — two real sites returned 9-byte bodies on the second
+> page through the pool. Adds `Page::reset_for_reuse()`, refreshes the dependency
+> tree, and clears two RUSTSEC advisories.
 
 ### Fixed
 - **`PagePool` / warm reuse leaked V8 heap without bound**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,57 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.1.3] — unreleased
+## [0.1.3]
 
-### Planned
-- `deno_core` 0.404 → 0.408
-  ([#37](https://github.com/yfedoseev/browser_oxide/issues/37)). Deferred from
-  0.1.2: 0.408 builds and passes the full suite in release, but aborts
-  (SIGABRT) during V8 isolate construction in debug builds on Linux. Needs a
-  debug repro and a 0.405–0.408 bisect before it can land.
+### Fixed
+- **A V8 isolate constructed outside a tokio runtime aborted the process**
+  ([#37](https://github.com/yfedoseev/browser_oxide/issues/37)). `deno_core`
+  0.408 captures `tokio::runtime::Handle::try_current()` when it registers an
+  isolate and spawns V8's *delayed* foreground tasks — GC memory-reducer work —
+  on that handle; with no handle it prints a diagnostic and calls
+  `std::process::abort()`. The synchronous constructors
+  (`BrowserJsRuntime::new` / `with_profile` / `with_options`) are public API
+  callable from a plain `fn main` or a `#[test]`, so they now enter a
+  process-lifetime fallback runtime when the caller has none. Applies to both
+  the page and worker realms.
+
+  Worth being precise, because it shaped the 0.1.2 release: the abort is
+  **not** debug-gated and **not** platform-specific. Release builds passed only
+  while V8 happened not to post a delayed task inside the window under test —
+  i.e. a latent production abort, which is why the bump was held back from
+  0.1.2 rather than shipped. Reproduced on Linux, macOS and Windows.
+
+### Added
+- **Environment-tunable V8 heap limits.** The right ceiling is a property of
+  the deployment, not of the engine, and the previous hard-coded 4 GB silently
+  over-committed small containers.
+  - `BROWSER_OXIDE_HEAP_MAX_MB` — default `4096` (4 GB)
+  - `BROWSER_OXIDE_HEAP_INITIAL_MB` — default `1024` (1 GB)
+
+  Unparseable or zero values fall back to the defaults with a warning rather
+  than failing; an initial above the ceiling is clamped, since V8 rejects that
+  pairing. Both are per-**isolate**, so a `PagePool` of N pages can commit up
+  to N × the ceiling — see [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md).
+
+### Dependencies
+- `deno_core` 0.404 → **0.408** (V8 149.2.0 → 149.4.0), the bump deferred from
+  0.1.2.
+
+### Changed
+- CI runs `cargo test` with `--nocapture`. Not cosmetic: libtest captures each
+  test's output and replays it only on failure, so when a test *aborts* the
+  reason dies with it. That is why #37 first surfaced as a bare
+  `signal: 6, SIGABRT` with no diagnosis. Any future abort-on-construction
+  would otherwise be undiagnosable from CI logs alone.
+
+### Verified
+- Canvas fingerprint byte-identical across the V8 bump —
+  `examples/canvas_fp_probe.rs` reports `len=17502 fnv1a=5b1d42ee9bdc9713`, the
+  same value as 0.1.1 and 0.1.2.
+- Real-site regression vs `main`, 15 open sites, both engine paths: zero
+  regressions; the warm-reuse fix from 0.1.2 still holds (pool 11/15 → 12/15).
+- Full CI matrix green on ubuntu (stable/beta/nightly), macOS and Windows —
+  including the debug jobs that previously aborted.
 
 ## [0.1.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.3] — unreleased
+
+### Planned
+- `deno_core` 0.404 → 0.408
+  ([#37](https://github.com/yfedoseev/browser_oxide/issues/37)). Deferred from
+  0.1.2: 0.408 builds and passes the full suite in release, but aborts
+  (SIGABRT) during V8 isolate construction in debug builds on Linux. Needs a
+  debug repro and a 0.405–0.408 bisect before it can land.
+
 ## [0.1.2]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "adblock",
  "async-trait",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "browser_oxide_mcp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "browser_oxide",
  "serde_json",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.404.0"
+version = "0.408.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed0bfc2096207522de1b7826b0fdd85587e19d0d61368411ad3f193166376b2"
+checksum = "9c1d2bf3bf9a7dd3f4184cf3af56ce9f06b7bb9cab93497ec3acd04196c9db3f"
 dependencies = [
  "anyhow",
  "az",
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.280.0"
+version = "0.284.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404a038088a57bb9d73e48975a0359d869e69edc450f4a30fe5416652b4b470"
+checksum = "2a12781597d3e7e407a83b9f11790d59fbcccb8cb32859f121b3b90291e1a026"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -2627,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.313.0"
+version = "0.317.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b033e7b24fef6a1c2b47c7a435568504955392440b3562a89dbd4b6a390c27a"
+checksum = "4f840e3a70bc8b320b014d4a6959c5d177c2a12e7aa561260843bd865cc86436"
 dependencies = [
  "deno_error",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/browser_oxide", "crates/browser_oxide_mcp"]
 exclude = ["crates/browser_oxide_py"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Yury Fedoseev"]
@@ -39,7 +39,7 @@ doc_overindented_list_items = "allow"
 # The single engine crate — depended on by browser_oxide_mcp. Explicit
 # version pinned to the workspace version so cargo-deny's `wildcards =
 # "deny"` rule doesn't trip on path-only `version = "*"` resolution.
-browser_oxide = { version = "0.1.2", path = "crates/browser_oxide" }
+browser_oxide = { version = "0.1.3", path = "crates/browser_oxide" }
 
 # Async runtime + common derive deps shared by multiple crates.
 tokio = { version = "1", features = ["full"] }

--- a/crates/browser_oxide/Cargo.toml
+++ b/crates/browser_oxide/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["full"] }
 futures-util = "0.3"
 async-trait = "0.1"
 # --- V8 / JS ---
-deno_core = "0.404"
+deno_core = "0.408"
 deno_error = "0.7"
 # --- serialization ---
 serde = { version = "1", features = ["derive"] }

--- a/crates/browser_oxide/src/js_runtime/runtime.rs
+++ b/crates/browser_oxide/src/js_runtime/runtime.rs
@@ -60,6 +60,108 @@ pub struct BrowserRuntimeOptions {
 /// (some sites expect a navigation to begin within a few seconds).
 /// Keeps this fn for existing callers
 /// that don't need the signal.
+/// Default V8 heap ceiling, in MiB. Overridable via
+/// `BROWSER_OXIDE_HEAP_MAX_MB`.
+pub const DEFAULT_HEAP_MAX_MB: usize = 4096;
+
+/// Default initial V8 heap reservation, in MiB. Overridable via
+/// `BROWSER_OXIDE_HEAP_INITIAL_MB`.
+///
+/// Not 256 MB: that caused early-growth GC pauses on fingerprint-heavy sites,
+/// where a heavy probe allocates well past 256 MB in a single pass and V8 spent
+/// time compacting old space before growing the heap. 1 GB skips those early
+/// compactions.
+pub const DEFAULT_HEAP_INITIAL_MB: usize = 1024;
+
+/// Resolve `(initial, max)` V8 heap limits in bytes.
+///
+/// Both are environment-tunable, which matters because the right ceiling is a
+/// property of the deployment, not of the engine: a 512 MB container and a
+/// 64 GB scraping host want very different numbers, and the previous
+/// hard-coded 4 GB silently over-committed the former.
+///
+/// - `BROWSER_OXIDE_HEAP_MAX_MB` — ceiling, default
+///   [`DEFAULT_HEAP_MAX_MB`] (4 GB).
+/// - `BROWSER_OXIDE_HEAP_INITIAL_MB` — initial reservation, default
+///   [`DEFAULT_HEAP_INITIAL_MB`] (1 GB).
+///
+/// Unparseable or zero values fall back to the defaults rather than failing:
+/// a typo in an env var should not take down a scrape. An initial larger than
+/// the max is clamped down to the max, since V8 treats that combination as a
+/// hard error.
+fn heap_limits() -> (usize, usize) {
+    fn mb_from_env(key: &str, default_mb: usize) -> usize {
+        match std::env::var(key) {
+            Ok(raw) => match raw.trim().parse::<usize>() {
+                Ok(mb) if mb > 0 => mb,
+                _ => {
+                    tracing::warn!(
+                        env = key,
+                        value = %raw,
+                        default_mb,
+                        "ignoring unparseable/zero heap limit; using default"
+                    );
+                    default_mb
+                }
+            },
+            Err(_) => default_mb,
+        }
+    }
+
+    let max_mb = mb_from_env("BROWSER_OXIDE_HEAP_MAX_MB", DEFAULT_HEAP_MAX_MB);
+    let initial_mb = mb_from_env("BROWSER_OXIDE_HEAP_INITIAL_MB", DEFAULT_HEAP_INITIAL_MB);
+    let initial_mb = initial_mb.min(max_mb);
+
+    const MIB: usize = 1024 * 1024;
+    (initial_mb * MIB, max_mb * MIB)
+}
+
+/// Guarantee a tokio runtime is entered for the duration of `JsRuntime`
+/// construction, falling back to a process-lifetime runtime if the caller has
+/// none.
+///
+/// Required as of `deno_core` 0.408. It captures
+/// `tokio::runtime::Handle::try_current()` at isolate-registration time
+/// (`runtime/jsruntime.rs`) and spawns V8's *delayed* foreground tasks — GC
+/// memory-reducer tasks and friends — on that handle. When the handle is
+/// `None`, `runtime/setup.rs::spawn_delayed_task` prints a diagnostic and calls
+/// `std::process::abort()`. Upstream aborts rather than panics deliberately:
+/// V8 invokes it from C++ frames Rust cannot unwind through.
+///
+/// Two things worth being precise about, because both misled the 0.1.2
+/// investigation (#37):
+///
+/// 1. **This is not debug-only.** The abort is unconditional. Release builds
+///    pass only while V8 happens not to post a delayed task in the window
+///    being exercised, which is timing, not safety.
+/// 2. **It is not the caller's bug to fix.** `BrowserJsRuntime::new` /
+///    `with_profile` / `with_options` are synchronous public API, callable from
+///    a plain `fn main` or a `#[test]`. Requiring every embedder to wrap
+///    construction in a runtime would be a silent breaking change whose
+///    failure mode is a process abort.
+///
+/// The captured handle must stay valid for the isolate's whole life, so the
+/// fallback runtime is a `OnceLock` living to process exit — a temporary would
+/// leave the isolate holding a handle to a dropped runtime.
+fn ensure_tokio_context() -> Option<tokio::runtime::EnterGuard<'static>> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return None;
+    }
+    static FALLBACK_RT: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    let rt = FALLBACK_RT.get_or_init(|| {
+        // Single worker + timer driver is all V8's delayed tasks need: they
+        // sleep, push onto the isolate's foreground queue, and wake it. The
+        // work itself is drained synchronously by our own event loop.
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_time()
+            .thread_name("browser-oxide-v8-delayed")
+            .build()
+            .expect("failed to build fallback tokio runtime for V8 delayed tasks")
+    });
+    Some(rt.enter())
+}
+
 pub fn create_runtime(dom: Dom, options: BrowserRuntimeOptions) -> JsRuntime {
     create_runtime_with_signals(dom, options).0
 }
@@ -115,13 +217,13 @@ pub fn create_runtime_with_signals(
     // property descriptors across every WebIDL interface). Real Chrome on
     // a desktop has 4 GB+ available per renderer; we mirror that.
     //
-    // HEAP_INITIAL was 256 MB but caused early-growth GC pauses on
-    // fingerprint-heavy sites (a heavy probe allocates well past 256 MB
-    // during its pass; V8 spent time compacting old space before
-    // growing the heap). 1 GB initial skips those early compactions.
-    const HEAP_INITIAL: usize = 1024 * 1024 * 1024; // 1 GB initial
-    const HEAP_MAX: usize = 4 * 1024 * 1024 * 1024; // 4 GB max
-    let create_params = deno_core::v8::CreateParams::default().heap_limits(HEAP_INITIAL, HEAP_MAX);
+    let (heap_initial, heap_max) = heap_limits();
+    let create_params = deno_core::v8::CreateParams::default().heap_limits(heap_initial, heap_max);
+
+    // Must outlive the `JsRuntime::new` call below — deno_core captures the
+    // current tokio handle during isolate registration. See
+    // `ensure_tokio_context`.
+    let _tokio_guard = ensure_tokio_context();
 
     let mut runtime = JsRuntime::new(RuntimeOptions {
         extensions: vec![
@@ -339,6 +441,11 @@ pub fn create_worker_runtime(
     profile: Option<StealthProfile>,
     is_secure_context: bool,
 ) -> JsRuntime {
+    // Same requirement as the page runtime — worker realms are built on their
+    // own threads, which may not have a runtime entered. See
+    // `ensure_tokio_context`.
+    let _tokio_guard = ensure_tokio_context();
+
     let mut runtime = JsRuntime::new(RuntimeOptions {
         extensions: vec![
             console_extension::init(),

--- a/crates/browser_oxide/tests/runtime_env.rs
+++ b/crates/browser_oxide/tests/runtime_env.rs
@@ -1,0 +1,93 @@
+//! Regression tests for the deno_core 0.408 tokio-context requirement (#37)
+//! and for env-tunable V8 heap limits.
+//!
+//! Deliberately **one** `#[test]` fn. Each check needs its own `JsRuntime`, and
+//! V8 requires `OwnedIsolate`s be dropped in reverse creation order; splitting
+//! these across test fns left isolates interleaving badly enough to abort the
+//! binary. Keeping them in one fn, each scoped and dropped before the next, makes
+//! the ordering explicit. It also keeps the `#[test]` (not `#[tokio::test]`)
+//! property that the #37 regression depends on.
+
+use browser_oxide::js_runtime::BrowserJsRuntime;
+
+fn dom() -> browser_oxide::dom::Dom {
+    browser_oxide::html_parser::parse_html("<html><body></body></html>")
+}
+
+/// The #37 regression, in the exact shape that aborted: a plain `#[test]`, so
+/// the harness enters no tokio runtime.
+///
+/// As of deno_core 0.408, `JsRuntime` construction captures
+/// `tokio::runtime::Handle::try_current()` and V8's delayed foreground tasks (GC
+/// memory-reducer work) are spawned on it. With no handle, deno_core prints a
+/// diagnostic and calls `std::process::abort()` the first time V8 posts one.
+///
+/// That abort is **not** debug-gated — release only passes while V8 happens not
+/// to post a delayed task in the window under test, which is why 0.408 looked
+/// green locally in release and died in CI. The heap churn below provokes GC
+/// scheduling so a latent abort becomes a reproducible one.
+///
+/// On regression the whole binary dies with SIGABRT instead of reporting a
+/// failure — look for "V8 posted a delayed task ... outside of a tokio runtime
+/// context" as the last line before the abort.
+#[test]
+fn runtime_env_and_tokio_context() {
+    assert!(
+        tokio::runtime::Handle::try_current().is_err(),
+        "precondition: must run with NO tokio runtime entered, or this cannot \
+         catch the #37 regression"
+    );
+
+    // 1. Construct with no runtime entered, and churn to provoke GC delayed tasks.
+    {
+        let mut rt = BrowserJsRuntime::new(dom());
+        assert_eq!(rt.execute_script("1 + 2", None).unwrap(), "3");
+        for i in 0..25 {
+            let src = format!(
+                "globalThis.k{i} = new Array(100000).fill('{i}'); globalThis.k{i} = null; 0"
+            );
+            rt.execute_script(&src, None).unwrap();
+        }
+        assert_eq!(rt.execute_script("1 + 1", None).unwrap(), "2");
+    }
+
+    // 2. Heap limits are read from the environment.
+    unsafe {
+        std::env::set_var("BROWSER_OXIDE_HEAP_MAX_MB", "512");
+        std::env::set_var("BROWSER_OXIDE_HEAP_INITIAL_MB", "64");
+    }
+    {
+        let mut rt = BrowserJsRuntime::new(dom());
+        assert_eq!(rt.execute_script("1 + 2", None).unwrap(), "3");
+    }
+
+    // 3. Garbage must fall back to the default, not panic — a typo in an env
+    //    var should not take down a scrape.
+    unsafe {
+        std::env::set_var("BROWSER_OXIDE_HEAP_MAX_MB", "not-a-number");
+        std::env::set_var("BROWSER_OXIDE_HEAP_INITIAL_MB", "0");
+    }
+    {
+        let mut rt = BrowserJsRuntime::new(dom());
+        assert_eq!(
+            rt.execute_script("1 + 2", None).unwrap(),
+            "3",
+            "unparseable/zero heap limits should fall back to defaults"
+        );
+    }
+
+    // 4. Initial above the ceiling must be clamped — V8 rejects that pairing.
+    unsafe {
+        std::env::set_var("BROWSER_OXIDE_HEAP_MAX_MB", "512");
+        std::env::set_var("BROWSER_OXIDE_HEAP_INITIAL_MB", "4096");
+    }
+    {
+        let mut rt = BrowserJsRuntime::new(dom());
+        assert_eq!(rt.execute_script("1 + 2", None).unwrap(), "3");
+    }
+
+    unsafe {
+        std::env::remove_var("BROWSER_OXIDE_HEAP_MAX_MB");
+        std::env::remove_var("BROWSER_OXIDE_HEAP_INITIAL_MB");
+    }
+}

--- a/crates/browser_oxide_py/Cargo.toml
+++ b/crates/browser_oxide_py/Cargo.toml
@@ -11,7 +11,7 @@
 
 [package]
 name = "browser_oxide_py"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -54,6 +54,20 @@ or for benchmark fairness.
 | `BROWSER_OXIDE_NO_SHARED_ACCEPT_CH` | If set, don't carry learned `Accept-CH` client-hint upgrades across navigations. |
 | `BROWSER_OXIDE_COOKIE_COLLISION_PAIRS` | Opt-in fix for stale cross-domain cookie collisions (e.g. a site reachable under two eTLD+1 identities after a rebrand, where inherited cookies make the WAF serve a stub). Comma-separated `<domain-a>=<domain-b>` pairs, e.g. `BROWSER_OXIDE_COOKIE_COLLISION_PAIRS="twitter.com=x.com"`. When the current host matches either side and the jar holds cookies for both, both are cleared. Unset (default) = no scrub; the engine ships no hardcoded domain pairs. |
 
+## V8 heap limits
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `BROWSER_OXIDE_HEAP_MAX_MB` | `4096` (4 GB) | V8 heap **ceiling** per isolate, in MiB. The right value is a property of your deployment, not of the engine — a 512 MB container and a 64 GB scraping host want very different numbers. Lower it to fail fast instead of getting OOM-killed; raise it for fingerprint-heavy sites that legitimately allocate past 4 GB. |
+| `BROWSER_OXIDE_HEAP_INITIAL_MB` | `1024` (1 GB) | Initial heap **reservation**, in MiB. Not smaller by default deliberately: at 256 MB, fingerprint-heavy probes that allocate well past that in one pass made V8 compact old space repeatedly before growing the heap. A larger initial reservation trades virtual address space for skipping those early compactions. |
+
+Both are per-**isolate**, so a `PagePool` of N pages can commit up to N × the
+ceiling. Size accordingly.
+
+Unparseable or zero values are ignored with a warning and the default is used —
+a typo should not take down a scrape. An initial larger than the ceiling is
+clamped down to it, because V8 rejects that combination outright.
+
 ## V8 snapshot & performance
 
 | Variable | Default | Effect |
@@ -61,6 +75,15 @@ or for benchmark fairness.
 | `BROWSER_OXIDE_USE_SNAPSHOT` | unset (**off**) | Set to `1` to enable the V8 startup snapshot (faster cold start). **Disabled by default** on V8-149 — snapshot *restore* currently segfaults; the cold-bootstrap path is used instead. |
 | `BROWSER_OXIDE_NO_SNAPSHOT_CACHE` | unset | Disable the on-disk snapshot cache (forces an in-memory build per process). |
 | `BROWSER_OXIDE_SNAPSHOT_CACHE` | system temp dir | Override the snapshot cache directory. |
+
+> **Note on embedding:** as of `deno_core` 0.408 a V8 isolate must be created
+> inside an entered tokio runtime — deno_core captures
+> `tokio::runtime::Handle::try_current()` at construction and spawns V8's
+> delayed foreground tasks (GC memory-reducer work) on it, calling
+> `std::process::abort()` if there is no handle. `browser_oxide` handles this
+> for you: the synchronous constructors enter a process-lifetime fallback
+> runtime when the caller has none, so `BrowserJsRuntime::new` remains safe to
+> call from a plain `fn main` or `#[test]`.
 
 ## Debugging & tracing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "browser-oxide"
-version = "0.1.2"
+version = "0.1.3"
 description = "BrowserOxide â€” stealth headless browser engine in Rust (Python bindings) â€” real HTML/CSS/DOM/JS, own BoringSSL TLS, native fingerprint, no Chromium"
 readme = "python/README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Draft. Scope for 0.1.3 is [#37](https://github.com/yfedoseev/browser_oxide/issues/37) — the `deno_core` 0.408 bump deferred from #35.

## Why this is a draft

0.408 is expected to **fail the ubuntu debug test jobs** with `signal: 6, SIGABRT` during V8 isolate construction. That is the known symptom from #37, reproduced deliberately. This PR exists to get the *reason*, which was invisible last time.

## The actual change of substance

`cargo test` now runs with `--nocapture`. That is not cosmetic: libtest captures each test`s stdout/stderr and replays it only on failure, so when a test **aborts the process** the captured output dies with it. In #35 that left a bare `signal: 6` against `workers::tests::create_worker` and `basic_js_execution` with no diagnosis, which is why the bump was reverted rather than fixed. Unbuffered output means the last line before an abort is the abort`s own message — a V8 `FATAL`, or a panic that could not unwind out of a V8 callback.

Worth keeping regardless of the outcome here: any future abort-on-construction is otherwise undiagnosable from CI logs alone.

## Ruled out so far

- **Not a stack overflow.** Rust detects those via its SIGSEGV handler and then calls `abort()`, so SIGABRT does not exclude it — but the CI log contains no `has overflowed its stack`, and `v8_recursion::test_thread_stack_is_at_least_16mb` passes in the same debug run. `.cargo/config.toml` already sets `RUST_MIN_STACK=67108864`.
- **Not a new deno_core assertion.** `debug_assert` counts in `runtime/jsruntime.rs`, `runtime/mod.rs`, `runtime/bindings.rs` and `runtime/jsrealm.rs` are identical between 0.404 and 0.408.
- **Not release-reachable.** On 0.408 in release the full suite passes, all 11 warm-reuse tests pass, the leak A/B is unchanged (1,040,662 -> 468 B per reuse), and `examples/canvas_fp_probe.rs` still reports `len=17502 fnv1a=5b1d42ee9bdc9713`.

Transitive V8 moves **149.2.0 -> 149.4.0** with this bump — the other candidate, and one deno_core`s own source diff cannot show.

## Next

1. Read the abort reason from the ubuntu debug jobs on this run.
2. If it is not conclusive, bisect 0.405 / 0.406 / 0.407.
3. Fix or report upstream, then mark ready for review.

Do not merge while the debug jobs are red.